### PR TITLE
7 new features + locale-aware AI responses

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "axios": "^1.6.0",
         "clsx": "^2.1.0",
+        "idb": "^8.0.3",
         "lucide-react": "^0.575.0",
+        "nanoid": "^5.1.7",
         "posthog-js": "^1.353.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -61,7 +63,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -898,7 +899,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2281,7 +2281,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2349,7 +2348,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2616,7 +2614,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2908,7 +2905,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3021,8 +3017,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -3240,7 +3235,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3838,6 +3832,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4182,10 +4182,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.7.tgz",
+      "integrity": "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==",
       "funding": [
         {
           "type": "github",
@@ -4194,10 +4193,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -4422,6 +4421,25 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/posthog-js": {
       "version": "1.353.1",
       "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.353.1.tgz",
@@ -4627,7 +4645,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4640,7 +4657,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5102,7 +5118,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5173,7 +5188,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "axios": "^1.6.0",
     "clsx": "^2.1.0",
+    "idb": "^8.0.3",
     "lucide-react": "^0.575.0",
+    "nanoid": "^5.1.7",
     "posthog-js": "^1.353.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { PenLine, Network, Sparkles, Github } from 'lucide-react'
+import { PenLine, Network, Sparkles, Github, History, Brain } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { initAnalytics, setSource, analytics } from '@/lib/analytics'
 import FlowCanvas from '@/components/FlowCanvas'
@@ -21,6 +21,14 @@ import { useLocale } from '@/i18n/LocaleContext'
 import { LOCALES, LOCALE_LABELS } from '@/i18n/translations'
 import type { Locale } from '@/i18n/translations'
 import { isExtension } from '@/lib/platform'
+import DebuggerPanel from '@/features/debugger/DebuggerPanel'
+import CompressorModal from '@/features/compressor/CompressorModal'
+import CriticPanel from '@/features/critic/CriticPanel'
+import SystemPromptModal from '@/features/system-prompt/SystemPromptModal'
+import MemoryPanel from '@/features/context-memory/MemoryPanel'
+import VersionHistory from '@/features/versioning/VersionHistory'
+import { useVersionStore } from '@/features/versioning/useVersionStore'
+import { useMemoryStore } from '@/features/context-memory/useMemoryStore'
 import './styles.css'
 
 const TAB_IDS: { id: Tab; Icon: LucideIcon }[] = [
@@ -30,10 +38,31 @@ const TAB_IDS: { id: Tab; Icon: LucideIcon }[] = [
 ]
 
 const App = () => {
-  const { undo, redo, activeTab, setActiveTab, isDecomposing } = useFlowStore()
+  const { undo, redo, activeTab, setActiveTab, isDecomposing, setRawPrompt } = useFlowStore()
   const { t, locale, setLocale } = useLocale()
+  const { currentProjectId } = useProjectStore()
+  const { setOpen: openVersions, load: loadVersions } = useVersionStore()
+  const { setOpen: openMemory } = useMemoryStore()
   const mainRef = useRef<HTMLElement>(null)
   const [libraryOpen, setLibraryOpen] = useState(false)
+
+  const handleOpenVersions = () => {
+    openVersions(true)
+    if (currentProjectId) loadVersions(currentProjectId)
+  }
+
+  const handleApplyDebugFix = (fixedPrompt: string) => {
+    setRawPrompt(fixedPrompt)
+  }
+
+  const handleApplyCompression = (compressed: string) => {
+    setRawPrompt(compressed)
+  }
+
+  const handleApplySystemPromptToCanvas = (sections: Array<{ name: string; content: string }>) => {
+    const full = sections.map(s => `## ${s.name}\n${s.content}`).join('\n\n')
+    setRawPrompt(full)
+  }
 
   // Init PostHog after first render — non-blocking
   useEffect(() => {
@@ -99,6 +128,12 @@ const App = () => {
           <div className="header-spacer" />
 
           <div className="header-actions">
+            <button className="btn-icon" title="Version History" onClick={handleOpenVersions} aria-label="Version History">
+              <History size={14} />
+            </button>
+            <button className="btn-icon" title="Context Memory" onClick={() => openMemory(true)} aria-label="Context Memory">
+              <Brain size={14} />
+            </button>
             <select
               className="btn-locale"
               value={locale}
@@ -181,6 +216,14 @@ const App = () => {
 
       {/* Make.com integration panel — web only */}
       {!isExtension && <MakeIntegration />}
+
+      {/* IDE feature panels — web only */}
+      {!isExtension && <DebuggerPanel onApplyFix={handleApplyDebugFix} />}
+      {!isExtension && <CompressorModal onApply={handleApplyCompression} />}
+      {!isExtension && <CriticPanel />}
+      {!isExtension && <SystemPromptModal onApplyToCanvas={handleApplySystemPromptToCanvas} />}
+      {!isExtension && <MemoryPanel />}
+      {!isExtension && <VersionHistory projectId={currentProjectId ?? '__default__'} />}
 
       <nav className="tab-bar" aria-label={t.accessibility.mainTabs}>
         <div role="tablist" className="tab-list-inner">

--- a/app/src/components/PromptInput.tsx
+++ b/app/src/components/PromptInput.tsx
@@ -207,9 +207,9 @@ const PromptInput = () => {
           className="btn btn-secondary"
           onClick={handleGenerateSystemPrompt}
           disabled={!rawPrompt.trim()}
-          title="Generate a structured system prompt"
+          title={t.ide.inputButtons.systemPrompt}
         >
-          <Wand2 size={13} /> System Prompt
+          <Wand2 size={13} /> {t.ide.inputButtons.systemPrompt}
         </button>
       )}
     </div>

--- a/app/src/components/PromptInput.tsx
+++ b/app/src/components/PromptInput.tsx
@@ -1,11 +1,12 @@
 import { useState, useRef, useEffect } from 'react'
-import { Zap, ClipboardPaste, Download } from 'lucide-react'
+import { Zap, ClipboardPaste, Download, Wand2 } from 'lucide-react'
 import { useFlowStore } from '@/store/flowStore'
-import { decomposePrompt, watchJobStatus, classifyError, classifyJobError } from '@/services/api'
+import { decomposePrompt, watchJobStatus, classifyError, classifyJobError, generateSystemPrompt } from '@/services/api'
 import { useLocale } from '@/i18n/LocaleContext'
 import { analytics, setSource } from '@/lib/analytics'
 import { isExtension } from '@/lib/platform'
 import { STAR_EVENT } from '@/components/StarPopup'
+import { useSystemPromptStore } from '@/features/system-prompt/useSystemPromptStore'
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
@@ -108,6 +109,23 @@ const PromptInput = () => {
     }
   }
 
+  const { setOpen: openSysPrompt, setLoading: setSysLoading, setResult: setSysResult, setError: setSysError } = useSystemPromptStore()
+
+  const handleGenerateSystemPrompt = async () => {
+    if (!rawPrompt.trim()) return
+    openSysPrompt(true)
+    setSysLoading(true)
+    setSysError(null)
+    try {
+      const result = await generateSystemPrompt(rawPrompt)
+      setSysResult(result)
+    } catch {
+      setSysError('System prompt generation failed.')
+    } finally {
+      setSysLoading(false)
+    }
+  }
+
   const handlePaste = async () => {
     try {
       const text = await navigator.clipboard.readText()
@@ -183,6 +201,17 @@ const PromptInput = () => {
         <Zap size={14} aria-hidden="true" />
         {isDecomposing ? t.promptInput.decomposing : t.promptInput.decompose}
       </button>
+
+      {!isExtension && (
+        <button
+          className="btn btn-secondary"
+          onClick={handleGenerateSystemPrompt}
+          disabled={!rawPrompt.trim()}
+          title="Generate a structured system prompt"
+        >
+          <Wand2 size={13} /> System Prompt
+        </button>
+      )}
     </div>
   )
 }

--- a/app/src/components/PromptInput.tsx
+++ b/app/src/components/PromptInput.tsx
@@ -20,7 +20,7 @@ const PromptInput = () => {
     setQueueStatus,
     setCompiledPrompt,
   } = useFlowStore()
-  const { t } = useLocale()
+  const { t, locale } = useLocale()
   const [error, setError] = useState<string | null>(null)
   const [platformName, setPlatformName] = useState<string | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -117,7 +117,7 @@ const PromptInput = () => {
     setSysLoading(true)
     setSysError(null)
     try {
-      const result = await generateSystemPrompt(rawPrompt)
+      const result = await generateSystemPrompt(rawPrompt, locale)
       setSysResult(result)
     } catch {
       setSysError('System prompt generation failed.')

--- a/app/src/components/PromptOutput.tsx
+++ b/app/src/components/PromptOutput.tsx
@@ -28,7 +28,7 @@ const FORMAT_OPTIONS: Array<{ format: OutputFormat; label: string; title: string
 
 const PromptOutput = () => {
   const { nodes, edges, compiledPrompt, setCompiledPrompt, outputFormat, setOutputFormat } = useFlowStore()
-  const { t } = useLocale()
+  const { t, locale } = useLocale()
   const { setIsPanelOpen: openMakePanel } = useMakeStore()
   const [copied,   setCopied]   = useState(false)
   const [injected, setInjected] = useState(false)
@@ -130,7 +130,7 @@ const PromptOutput = () => {
     setCriticLoading(true)
     setCriticError(null)
     try {
-      const result = await critiquePrompt(currentRaw)
+      const result = await critiquePrompt(currentRaw, locale)
       setCriticResult(result as CriticResult)
     } catch {
       setCriticError('Evaluation failed. Please try again.')

--- a/app/src/components/PromptOutput.tsx
+++ b/app/src/components/PromptOutput.tsx
@@ -224,14 +224,14 @@ const PromptOutput = () => {
             </div>
             {!isExtension && (
               <div className="output-ide-actions">
-                <button className="btn btn-secondary export-btn" onClick={handleDebug} title="Analyze prompt issues">
-                  <Bug size={13} /> Debug
+                <button className="btn btn-secondary export-btn" onClick={handleDebug} title={t.ide.outputButtons.debug}>
+                  <Bug size={13} /> {t.ide.outputButtons.debug}
                 </button>
-                <button className="btn btn-secondary export-btn" onClick={handleCompress} title="Compress prompt tokens">
-                  <Scissors size={13} /> Compress
+                <button className="btn btn-secondary export-btn" onClick={handleCompress} title={t.ide.outputButtons.compress}>
+                  <Scissors size={13} /> {t.ide.outputButtons.compress}
                 </button>
-                <button className="btn btn-secondary export-btn" onClick={handleCritic} title="Score prompt quality">
-                  <StarIcon size={13} /> Score
+                <button className="btn btn-secondary export-btn" onClick={handleCritic} title={t.ide.outputButtons.score}>
+                  <StarIcon size={13} /> {t.ide.outputButtons.score}
                 </button>
               </div>
             )}

--- a/app/src/components/PromptOutput.tsx
+++ b/app/src/components/PromptOutput.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react'
-import { Clipboard, ClipboardCheck, FileText, Braces, Sparkles, Play, Send, Github, Zap } from 'lucide-react'
+import { Clipboard, ClipboardCheck, FileText, Braces, Sparkles, Play, Send, Github, Zap, Bug, Scissors, Star as StarIcon } from 'lucide-react'
 import { useFlowStore } from '@/store/flowStore'
 import { useLocale } from '@/i18n/LocaleContext'
 import { analytics } from '@/lib/analytics'
@@ -8,6 +8,14 @@ import { isExtension } from '@/lib/platform'
 import { STAR_EVENT } from '@/components/StarPopup'
 import { useMakeStore } from '@/store/makeStore'
 import type { OutputFormat } from '@/types/blocks'
+import CostPopover from '@/features/cost-estimator/CostPopover'
+import { useDebuggerStore } from '@/features/debugger/useDebuggerStore'
+import { useCompressorStore } from '@/features/compressor/useCompressorStore'
+import { useCriticStore } from '@/features/critic/useCriticStore'
+import { debugPrompt, compressPrompt, critiquePrompt } from '@/services/api'
+import type { DebugResult } from '@/features/debugger/types'
+import type { CompressResult } from '@/features/compressor/types'
+import type { CriticResult } from '@/features/critic/types'
 
 // ─── Selection button config ─────────────────────────────────────────────────
 const FORMAT_OPTIONS: Array<{ format: OutputFormat; label: string; title: string }> = [
@@ -82,6 +90,55 @@ const PromptOutput = () => {
     analytics.promptExported('json')
   }
 
+  const { setOpen: openDebugger, setLoading: setDebugLoading, setResult: setDebugResult, setError: setDebugError } = useDebuggerStore()
+  const { setOpen: openCompressor, setLoading: setCompressLoading, setResult: setCompressResult, setError: setCompressError, targetReduction } = useCompressorStore()
+  const { setOpen: openCritic, setLoading: setCriticLoading, setResult: setCriticResult, setError: setCriticError } = useCriticStore()
+
+  const handleDebug = async () => {
+    if (!currentRaw) return
+    openDebugger(true)
+    setDebugLoading(true)
+    setDebugError(null)
+    try {
+      const result = await debugPrompt(currentRaw)
+      setDebugResult(result as DebugResult)
+    } catch {
+      setDebugError('Debug failed. Please try again.')
+    } finally {
+      setDebugLoading(false)
+    }
+  }
+
+  const handleCompress = async () => {
+    if (!currentRaw) return
+    openCompressor(true)
+    setCompressLoading(true)
+    setCompressError(null)
+    try {
+      const result = await compressPrompt(currentRaw, targetReduction)
+      setCompressResult(result as CompressResult)
+    } catch {
+      setCompressError('Compression failed. Please try again.')
+    } finally {
+      setCompressLoading(false)
+    }
+  }
+
+  const handleCritic = async () => {
+    if (!currentRaw) return
+    openCritic(true)
+    setCriticLoading(true)
+    setCriticError(null)
+    try {
+      const result = await critiquePrompt(currentRaw)
+      setCriticResult(result as CriticResult)
+    } catch {
+      setCriticError('Evaluation failed. Please try again.')
+    } finally {
+      setCriticLoading(false)
+    }
+  }
+
   /** Sends the compiled prompt (current format) to the extension content script */
   const handleInjectToAI = useCallback(() => {
     if (!currentRaw) return
@@ -98,7 +155,7 @@ const PromptOutput = () => {
       <div className="output-header">
         <h2 className="panel-title">{t.promptOutput.title}</h2>
         {compiledPrompt && (
-          <span className="token-badge">~{compiledPrompt.tokenEstimate} tokens</span>
+          <CostPopover tokens={compiledPrompt.tokenEstimate} />
         )}
       </div>
 
@@ -165,6 +222,19 @@ const PromptOutput = () => {
                 <Braces size={13} aria-hidden="true" /> {t.promptOutput.exportJson}
               </button>
             </div>
+            {!isExtension && (
+              <div className="output-ide-actions">
+                <button className="btn btn-secondary export-btn" onClick={handleDebug} title="Analyze prompt issues">
+                  <Bug size={13} /> Debug
+                </button>
+                <button className="btn btn-secondary export-btn" onClick={handleCompress} title="Compress prompt tokens">
+                  <Scissors size={13} /> Compress
+                </button>
+                <button className="btn btn-secondary export-btn" onClick={handleCritic} title="Score prompt quality">
+                  <StarIcon size={13} /> Score
+                </button>
+              </div>
+            )}
           </div>
         </>
       ) : (

--- a/app/src/components/PromptOutput.tsx
+++ b/app/src/components/PromptOutput.tsx
@@ -100,7 +100,7 @@ const PromptOutput = () => {
     setDebugLoading(true)
     setDebugError(null)
     try {
-      const result = await debugPrompt(currentRaw)
+      const result = await debugPrompt(currentRaw, locale)
       setDebugResult(result as DebugResult)
     } catch {
       setDebugError('Debug failed. Please try again.')
@@ -115,7 +115,7 @@ const PromptOutput = () => {
     setCompressLoading(true)
     setCompressError(null)
     try {
-      const result = await compressPrompt(currentRaw, targetReduction)
+      const result = await compressPrompt(currentRaw, targetReduction, locale)
       setCompressResult(result as CompressResult)
     } catch {
       setCompressError('Compression failed. Please try again.')

--- a/app/src/features/compressor/CompressorModal.tsx
+++ b/app/src/features/compressor/CompressorModal.tsx
@@ -1,5 +1,6 @@
 import { X, Scissors, Trash2, GitMerge, Loader } from 'lucide-react'
 import { useCompressorStore } from './useCompressorStore'
+import { useLocale } from '@/i18n/LocaleContext'
 import type { CompressChange } from './types'
 
 function changeIcon(type: CompressChange['type']) {
@@ -14,6 +15,8 @@ interface Props {
 
 export default function CompressorModal({ onApply }: Props) {
   const { isOpen, isLoading, result, error, targetReduction, setOpen, setTargetReduction } = useCompressorStore()
+  const { t } = useLocale()
+  const tc = t.ide.compressor
 
   if (!isOpen) return null
 
@@ -24,17 +27,17 @@ export default function CompressorModal({ onApply }: Props) {
   ]
 
   return (
-    <div className="compressor-overlay" role="dialog" aria-modal="true" aria-label="Prompt Compressor">
+    <div className="compressor-overlay" role="dialog" aria-modal="true" aria-label={tc.title}>
       <div className="compressor-backdrop" onClick={() => setOpen(false)} />
       <div className="compressor-modal">
         <div className="compressor-header">
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <Scissors size={15} />
-            <span className="compressor-title">Prompt Compressor</span>
+            <span className="compressor-title">{tc.title}</span>
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
             <div className="compressor-target-row">
-              <span className="debugger-section-label">Target reduction:</span>
+              <span className="debugger-section-label">{tc.targetReduction}</span>
               {reductionOptions.map(opt => (
                 <button
                   key={opt.value}
@@ -46,8 +49,8 @@ export default function CompressorModal({ onApply }: Props) {
                 </button>
               ))}
             </div>
-            <button className="make-close-btn" onClick={() => setOpen(false)} aria-label="Close">
-              <X size={14} />
+            <button className="ide-close-btn" onClick={() => setOpen(false)} aria-label={t.ide.close}>
+              <X size={15} />
             </button>
           </div>
         </div>
@@ -55,7 +58,7 @@ export default function CompressorModal({ onApply }: Props) {
         {isLoading && (
           <div className="debugger-loading" style={{ padding: 40 }}>
             <Loader size={20} className="spin" />
-            <span>Compressing…</span>
+            <span>{tc.loading}</span>
           </div>
         )}
 
@@ -67,37 +70,39 @@ export default function CompressorModal({ onApply }: Props) {
           <div className="compressor-body">
             <div className="compressor-stats">
               <div className="compressor-stat">
-                <span className="compressor-stat-label">Before</span>
-                <span className="compressor-stat-value">{result.tokensBefore} words</span>
+                <span className="compressor-stat-label">{tc.before}</span>
+                <span className="compressor-stat-value">{result.tokensBefore} <small>{tc.words}</small></span>
               </div>
               <div className="compressor-stat">
-                <span className="compressor-stat-label">After</span>
-                <span className="compressor-stat-value" style={{ color: '#22c55e' }}>{result.tokensAfter} words</span>
+                <span className="compressor-stat-label">{tc.after}</span>
+                <span className="compressor-stat-value" style={{ color: '#22c55e' }}>{result.tokensAfter} <small>{tc.words}</small></span>
               </div>
               <div className="compressor-stat">
-                <span className="compressor-stat-label">Saved</span>
+                <span className="compressor-stat-label">{tc.saved}</span>
                 <span className="compressor-stat-value" style={{ color: '#22c55e' }}>-{result.reductionPercent}%</span>
               </div>
             </div>
 
             <div className="compressor-columns">
               <div className="compressor-col">
-                <span className="debugger-section-label">Original</span>
-                <pre className="compressor-pre">{result.changes.map(c => c.original).join('\n') || '(no changes)'}</pre>
+                <span className="debugger-section-label">{tc.original}</span>
+                <pre className="compressor-pre">
+                  {result.changes.map(c => c.original).join('\n') || tc.noChanges}
+                </pre>
               </div>
               <div className="compressor-col">
-                <span className="debugger-section-label">Compressed prompt</span>
+                <span className="debugger-section-label">{tc.compressed}</span>
                 <pre className="compressor-pre">{result.compressedPrompt}</pre>
               </div>
             </div>
 
             {result.changes.length > 0 && (
               <div className="compressor-changes">
-                <span className="debugger-section-label">Changes ({result.changes.length})</span>
+                <span className="debugger-section-label">{tc.changes} ({result.changes.length})</span>
                 <ul className="compressor-change-list">
                   {result.changes.map((c, i) => (
                     <li key={i} className="compressor-change-item">
-                      {changeIcon(c.type)}
+                      {changeIcon(c.type as CompressChange['type'])}
                       <span className="compressor-change-type">{c.type}</span>
                       <span className="compressor-change-reason">{c.reason}</span>
                       <span className="compressor-change-saved">-{c.tokensSaved}w</span>
@@ -112,9 +117,13 @@ export default function CompressorModal({ onApply }: Props) {
               style={{ margin: '12px 16px 16px' }}
               onClick={() => { onApply(result.compressedPrompt); setOpen(false) }}
             >
-              Apply Compressed Prompt
+              {tc.apply}
             </button>
           </div>
+        )}
+
+        {!isLoading && !result && !error && (
+          <div className="debugger-empty" style={{ padding: 32 }}></div>
         )}
       </div>
     </div>

--- a/app/src/features/compressor/CompressorModal.tsx
+++ b/app/src/features/compressor/CompressorModal.tsx
@@ -1,0 +1,122 @@
+import { X, Scissors, Trash2, GitMerge, Loader } from 'lucide-react'
+import { useCompressorStore } from './useCompressorStore'
+import type { CompressChange } from './types'
+
+function changeIcon(type: CompressChange['type']) {
+  if (type === 'removed') return <Trash2 size={11} style={{ color: '#ef4444' }} />
+  if (type === 'optimized') return <Scissors size={11} style={{ color: '#f59e0b' }} />
+  return <GitMerge size={11} style={{ color: '#60a5fa' }} />
+}
+
+interface Props {
+  onApply: (compressed: string) => void
+}
+
+export default function CompressorModal({ onApply }: Props) {
+  const { isOpen, isLoading, result, error, targetReduction, setOpen, setTargetReduction } = useCompressorStore()
+
+  if (!isOpen) return null
+
+  const reductionOptions = [
+    { value: 0.3, label: '30%' },
+    { value: 0.5, label: '50%' },
+    { value: 0.7, label: '70%' },
+  ]
+
+  return (
+    <div className="compressor-overlay" role="dialog" aria-modal="true" aria-label="Prompt Compressor">
+      <div className="compressor-backdrop" onClick={() => setOpen(false)} />
+      <div className="compressor-modal">
+        <div className="compressor-header">
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <Scissors size={15} />
+            <span className="compressor-title">Prompt Compressor</span>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <div className="compressor-target-row">
+              <span className="debugger-section-label">Target reduction:</span>
+              {reductionOptions.map(opt => (
+                <button
+                  key={opt.value}
+                  className={`format-btn${targetReduction === opt.value ? ' format-btn-active' : ''}`}
+                  onClick={() => setTargetReduction(opt.value)}
+                  style={{ padding: '2px 8px', fontSize: 11 }}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+            <button className="make-close-btn" onClick={() => setOpen(false)} aria-label="Close">
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+
+        {isLoading && (
+          <div className="debugger-loading" style={{ padding: 40 }}>
+            <Loader size={20} className="spin" />
+            <span>Compressing…</span>
+          </div>
+        )}
+
+        {error && !isLoading && (
+          <div className="debugger-error" style={{ margin: 16 }}>{error}</div>
+        )}
+
+        {result && !isLoading && (
+          <div className="compressor-body">
+            <div className="compressor-stats">
+              <div className="compressor-stat">
+                <span className="compressor-stat-label">Before</span>
+                <span className="compressor-stat-value">{result.tokensBefore} words</span>
+              </div>
+              <div className="compressor-stat">
+                <span className="compressor-stat-label">After</span>
+                <span className="compressor-stat-value" style={{ color: '#22c55e' }}>{result.tokensAfter} words</span>
+              </div>
+              <div className="compressor-stat">
+                <span className="compressor-stat-label">Saved</span>
+                <span className="compressor-stat-value" style={{ color: '#22c55e' }}>-{result.reductionPercent}%</span>
+              </div>
+            </div>
+
+            <div className="compressor-columns">
+              <div className="compressor-col">
+                <span className="debugger-section-label">Original</span>
+                <pre className="compressor-pre">{result.changes.map(c => c.original).join('\n') || '(no changes)'}</pre>
+              </div>
+              <div className="compressor-col">
+                <span className="debugger-section-label">Compressed prompt</span>
+                <pre className="compressor-pre">{result.compressedPrompt}</pre>
+              </div>
+            </div>
+
+            {result.changes.length > 0 && (
+              <div className="compressor-changes">
+                <span className="debugger-section-label">Changes ({result.changes.length})</span>
+                <ul className="compressor-change-list">
+                  {result.changes.map((c, i) => (
+                    <li key={i} className="compressor-change-item">
+                      {changeIcon(c.type)}
+                      <span className="compressor-change-type">{c.type}</span>
+                      <span className="compressor-change-reason">{c.reason}</span>
+                      <span className="compressor-change-saved">-{c.tokensSaved}w</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <button
+              className="debugger-apply-btn"
+              style={{ margin: '12px 16px 16px' }}
+              onClick={() => { onApply(result.compressedPrompt); setOpen(false) }}
+            >
+              Apply Compressed Prompt
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/src/features/compressor/types.ts
+++ b/app/src/features/compressor/types.ts
@@ -1,0 +1,15 @@
+export interface CompressChange {
+  type: 'removed' | 'optimized' | 'merged'
+  original: string
+  replacement: string | null
+  reason: string
+  tokensSaved: number
+}
+
+export interface CompressResult {
+  compressedPrompt: string
+  changes: CompressChange[]
+  tokensBefore: number
+  tokensAfter: number
+  reductionPercent: number
+}

--- a/app/src/features/compressor/useCompressorStore.ts
+++ b/app/src/features/compressor/useCompressorStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand'
+import type { CompressResult } from './types'
+
+interface CompressorState {
+  isOpen: boolean
+  isLoading: boolean
+  result: CompressResult | null
+  error: string | null
+  targetReduction: number
+  setOpen: (open: boolean) => void
+  setLoading: (loading: boolean) => void
+  setResult: (result: CompressResult | null) => void
+  setError: (error: string | null) => void
+  setTargetReduction: (v: number) => void
+}
+
+export const useCompressorStore = create<CompressorState>((set) => ({
+  isOpen: false,
+  isLoading: false,
+  result: null,
+  error: null,
+  targetReduction: 0.5,
+  setOpen: (isOpen) => set({ isOpen }),
+  setLoading: (isLoading) => set({ isLoading }),
+  setResult: (result) => set({ result }),
+  setError: (error) => set({ error }),
+  setTargetReduction: (targetReduction) => set({ targetReduction }),
+}))

--- a/app/src/features/context-memory/MemoryPanel.tsx
+++ b/app/src/features/context-memory/MemoryPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { X, Brain, Plus, Trash2, Star, Search, LogIn } from 'lucide-react'
 import { useMemoryStore } from './useMemoryStore'
+import { useLocale } from '@/i18n/LocaleContext'
 import type { BlockType } from '@/types/blocks'
 import type { MemoryBlock } from '@/lib/db'
 
@@ -21,6 +22,8 @@ const emptyForm = (): CreateFormState => ({
 
 export default function MemoryPanel() {
   const { blocks, isOpen, searchQuery, setOpen, setSearch, create, remove, inject, toggleFavorite } = useMemoryStore()
+  const { t } = useLocale()
+  const tm = t.ide.memory
   const [showCreate, setShowCreate] = useState(false)
   const [form, setForm] = useState<CreateFormState>(emptyForm())
 
@@ -28,7 +31,7 @@ export default function MemoryPanel() {
 
   const filtered = blocks.filter(b => {
     const q = searchQuery.toLowerCase()
-    return !q || b.name.toLowerCase().includes(q) || b.content.toLowerCase().includes(q) || b.tags.some(t => t.toLowerCase().includes(q))
+    return !q || b.name.toLowerCase().includes(q) || b.content.toLowerCase().includes(q) || b.tags.some(tag => tag.toLowerCase().includes(q))
   }).sort((a, b) => (b.isFavorite ? 1 : 0) - (a.isFavorite ? 1 : 0))
 
   const handleCreate = async () => {
@@ -38,7 +41,7 @@ export default function MemoryPanel() {
       category: form.category,
       blockType: form.blockType,
       content: form.content.trim(),
-      tags: form.tags.split(',').map(t => t.trim()).filter(Boolean),
+      tags: form.tags.split(',').map(tag => tag.trim()).filter(Boolean),
       isFavorite: false,
     })
     setForm(emptyForm())
@@ -48,51 +51,51 @@ export default function MemoryPanel() {
   return (
     <>
       <div className="debugger-backdrop" onClick={() => setOpen(false)} />
-      <aside className="memory-panel" role="dialog" aria-label="Context Memory" aria-modal="true">
+      <aside className="memory-panel" role="dialog" aria-label={tm.title} aria-modal="true">
         <div className="debugger-header">
           <div className="debugger-brand">
             <Brain size={15} />
-            <span className="debugger-title">Context Memory</span>
+            <span className="debugger-title">{tm.title}</span>
           </div>
-          <div style={{ display: 'flex', gap: 6 }}>
-            <button className="btn btn-secondary export-btn" style={{ fontSize: 11, padding: '3px 8px' }} onClick={() => setShowCreate(s => !s)}>
-              <Plus size={11} /> New
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <button className="ide-action-btn" onClick={() => setShowCreate(s => !s)}>
+              <Plus size={11} /> {tm.new}
             </button>
-            <button className="make-close-btn" onClick={() => setOpen(false)} aria-label="Close">
-              <X size={14} />
+            <button className="ide-close-btn" onClick={() => setOpen(false)} aria-label={t.ide.close}>
+              <X size={15} />
             </button>
           </div>
         </div>
 
         {showCreate && (
           <div className="memory-create-form">
-            <input className="make-webhook-input" placeholder="Name" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} />
+            <input className="make-webhook-input" placeholder={tm.namePlaceholder} value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} />
             <div style={{ display: 'flex', gap: 6 }}>
               <select className="make-webhook-input" style={{ flex: 1 }} value={form.category} onChange={e => setForm(f => ({ ...f, category: e.target.value as typeof CATEGORIES[number] }))}>
                 {CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
               </select>
               <select className="make-webhook-input" style={{ flex: 1 }} value={form.blockType} onChange={e => setForm(f => ({ ...f, blockType: e.target.value as BlockType }))}>
-                {BLOCK_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+                {BLOCK_TYPES.map(bt => <option key={bt} value={bt}>{bt}</option>)}
               </select>
             </div>
-            <textarea className="make-webhook-input" style={{ minHeight: 80, resize: 'vertical', fontFamily: 'inherit' }} placeholder="Content…" value={form.content} onChange={e => setForm(f => ({ ...f, content: e.target.value }))} />
-            <input className="make-webhook-input" placeholder="Tags (comma separated)" value={form.tags} onChange={e => setForm(f => ({ ...f, tags: e.target.value }))} />
+            <textarea className="make-webhook-input" style={{ minHeight: 80, resize: 'vertical', fontFamily: 'inherit' }} placeholder={tm.contentPlaceholder} value={form.content} onChange={e => setForm(f => ({ ...f, content: e.target.value }))} />
+            <input className="make-webhook-input" placeholder={tm.tagsPlaceholder} value={form.tags} onChange={e => setForm(f => ({ ...f, tags: e.target.value }))} />
             <div style={{ display: 'flex', gap: 6 }}>
-              <button className="debugger-apply-btn" style={{ flex: 1, margin: 0 }} onClick={handleCreate}>Save</button>
-              <button className="btn btn-secondary export-btn" style={{ flex: 1 }} onClick={() => { setShowCreate(false); setForm(emptyForm()) }}>Cancel</button>
+              <button className="debugger-apply-btn" style={{ flex: 1, margin: 0 }} onClick={handleCreate}>{tm.save}</button>
+              <button className="ide-action-btn" style={{ flex: 1, justifyContent: 'center' }} onClick={() => { setShowCreate(false); setForm(emptyForm()) }}>{tm.cancel}</button>
             </div>
           </div>
         )}
 
         <div className="memory-search">
           <Search size={12} className="memory-search-icon" />
-          <input className="memory-search-input" placeholder="Search memory…" value={searchQuery} onChange={e => setSearch(e.target.value)} />
+          <input className="memory-search-input" placeholder={tm.searchPlaceholder} value={searchQuery} onChange={e => setSearch(e.target.value)} />
         </div>
 
         <div className="memory-list">
           {filtered.length === 0 && (
             <div className="debugger-empty">
-              {blocks.length === 0 ? 'No memory blocks yet. Click "+ New" to add one.' : 'No results.'}
+              {blocks.length === 0 ? tm.noBlocks : tm.noResults}
             </div>
           )}
           {filtered.map((block: MemoryBlock) => (
@@ -103,13 +106,13 @@ export default function MemoryPanel() {
                   <span className="memory-item-category">{block.category}</span>
                 </div>
                 <div className="memory-item-actions">
-                  <button className="make-close-btn" title="Inject to canvas" onClick={() => inject(block)}>
+                  <button className="ide-close-btn" style={{ width: 26, height: 26 }} title="Inject to canvas" onClick={() => inject(block)}>
                     <LogIn size={12} />
                   </button>
-                  <button className="make-close-btn" title={block.isFavorite ? 'Unfavorite' : 'Favorite'} onClick={() => toggleFavorite(block.id)}>
+                  <button className="ide-close-btn" style={{ width: 26, height: 26 }} title={block.isFavorite ? 'Unfavorite' : 'Favorite'} onClick={() => toggleFavorite(block.id)}>
                     <Star size={12} style={{ fill: block.isFavorite ? '#f59e0b' : 'none', color: '#f59e0b' }} />
                   </button>
-                  <button className="make-close-btn" title="Delete" onClick={() => remove(block.id)}>
+                  <button className="ide-close-btn ide-close-btn--danger" style={{ width: 26, height: 26 }} title="Delete" onClick={() => remove(block.id)}>
                     <Trash2 size={12} />
                   </button>
                 </div>
@@ -117,7 +120,7 @@ export default function MemoryPanel() {
               <p className="memory-item-preview">{block.content.slice(0, 120)}{block.content.length > 120 ? '…' : ''}</p>
               {block.tags.length > 0 && (
                 <div className="memory-item-tags">
-                  {block.tags.map(t => <span key={t} className="memory-item-tag">{t}</span>)}
+                  {block.tags.map(tag => <span key={tag} className="memory-item-tag">{tag}</span>)}
                 </div>
               )}
             </div>

--- a/app/src/features/context-memory/MemoryPanel.tsx
+++ b/app/src/features/context-memory/MemoryPanel.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react'
+import { X, Brain, Plus, Trash2, Star, Search, LogIn } from 'lucide-react'
+import { useMemoryStore } from './useMemoryStore'
+import type { BlockType } from '@/types/blocks'
+import type { MemoryBlock } from '@/lib/db'
+
+const CATEGORIES = ['company', 'persona', 'style', 'tone', 'domain', 'custom'] as const
+const BLOCK_TYPES: BlockType[] = ['role', 'context', 'objective', 'constraints', 'audience', 'goal']
+
+interface CreateFormState {
+  name: string
+  category: typeof CATEGORIES[number]
+  blockType: BlockType
+  content: string
+  tags: string
+}
+
+const emptyForm = (): CreateFormState => ({
+  name: '', category: 'custom', blockType: 'context', content: '', tags: ''
+})
+
+export default function MemoryPanel() {
+  const { blocks, isOpen, searchQuery, setOpen, setSearch, create, remove, inject, toggleFavorite } = useMemoryStore()
+  const [showCreate, setShowCreate] = useState(false)
+  const [form, setForm] = useState<CreateFormState>(emptyForm())
+
+  if (!isOpen) return null
+
+  const filtered = blocks.filter(b => {
+    const q = searchQuery.toLowerCase()
+    return !q || b.name.toLowerCase().includes(q) || b.content.toLowerCase().includes(q) || b.tags.some(t => t.toLowerCase().includes(q))
+  }).sort((a, b) => (b.isFavorite ? 1 : 0) - (a.isFavorite ? 1 : 0))
+
+  const handleCreate = async () => {
+    if (!form.name.trim() || !form.content.trim()) return
+    await create({
+      name: form.name.trim(),
+      category: form.category,
+      blockType: form.blockType,
+      content: form.content.trim(),
+      tags: form.tags.split(',').map(t => t.trim()).filter(Boolean),
+      isFavorite: false,
+    })
+    setForm(emptyForm())
+    setShowCreate(false)
+  }
+
+  return (
+    <>
+      <div className="debugger-backdrop" onClick={() => setOpen(false)} />
+      <aside className="memory-panel" role="dialog" aria-label="Context Memory" aria-modal="true">
+        <div className="debugger-header">
+          <div className="debugger-brand">
+            <Brain size={15} />
+            <span className="debugger-title">Context Memory</span>
+          </div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <button className="btn btn-secondary export-btn" style={{ fontSize: 11, padding: '3px 8px' }} onClick={() => setShowCreate(s => !s)}>
+              <Plus size={11} /> New
+            </button>
+            <button className="make-close-btn" onClick={() => setOpen(false)} aria-label="Close">
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+
+        {showCreate && (
+          <div className="memory-create-form">
+            <input className="make-webhook-input" placeholder="Name" value={form.name} onChange={e => setForm(f => ({ ...f, name: e.target.value }))} />
+            <div style={{ display: 'flex', gap: 6 }}>
+              <select className="make-webhook-input" style={{ flex: 1 }} value={form.category} onChange={e => setForm(f => ({ ...f, category: e.target.value as typeof CATEGORIES[number] }))}>
+                {CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+              </select>
+              <select className="make-webhook-input" style={{ flex: 1 }} value={form.blockType} onChange={e => setForm(f => ({ ...f, blockType: e.target.value as BlockType }))}>
+                {BLOCK_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+              </select>
+            </div>
+            <textarea className="make-webhook-input" style={{ minHeight: 80, resize: 'vertical', fontFamily: 'inherit' }} placeholder="Content…" value={form.content} onChange={e => setForm(f => ({ ...f, content: e.target.value }))} />
+            <input className="make-webhook-input" placeholder="Tags (comma separated)" value={form.tags} onChange={e => setForm(f => ({ ...f, tags: e.target.value }))} />
+            <div style={{ display: 'flex', gap: 6 }}>
+              <button className="debugger-apply-btn" style={{ flex: 1, margin: 0 }} onClick={handleCreate}>Save</button>
+              <button className="btn btn-secondary export-btn" style={{ flex: 1 }} onClick={() => { setShowCreate(false); setForm(emptyForm()) }}>Cancel</button>
+            </div>
+          </div>
+        )}
+
+        <div className="memory-search">
+          <Search size={12} className="memory-search-icon" />
+          <input className="memory-search-input" placeholder="Search memory…" value={searchQuery} onChange={e => setSearch(e.target.value)} />
+        </div>
+
+        <div className="memory-list">
+          {filtered.length === 0 && (
+            <div className="debugger-empty">
+              {blocks.length === 0 ? 'No memory blocks yet. Click "+ New" to add one.' : 'No results.'}
+            </div>
+          )}
+          {filtered.map((block: MemoryBlock) => (
+            <div key={block.id} className="memory-item">
+              <div className="memory-item-header">
+                <div>
+                  <span className="memory-item-name">{block.name}</span>
+                  <span className="memory-item-category">{block.category}</span>
+                </div>
+                <div className="memory-item-actions">
+                  <button className="make-close-btn" title="Inject to canvas" onClick={() => inject(block)}>
+                    <LogIn size={12} />
+                  </button>
+                  <button className="make-close-btn" title={block.isFavorite ? 'Unfavorite' : 'Favorite'} onClick={() => toggleFavorite(block.id)}>
+                    <Star size={12} style={{ fill: block.isFavorite ? '#f59e0b' : 'none', color: '#f59e0b' }} />
+                  </button>
+                  <button className="make-close-btn" title="Delete" onClick={() => remove(block.id)}>
+                    <Trash2 size={12} />
+                  </button>
+                </div>
+              </div>
+              <p className="memory-item-preview">{block.content.slice(0, 120)}{block.content.length > 120 ? '…' : ''}</p>
+              {block.tags.length > 0 && (
+                <div className="memory-item-tags">
+                  {block.tags.map(t => <span key={t} className="memory-item-tag">{t}</span>)}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </aside>
+    </>
+  )
+}

--- a/app/src/features/context-memory/useMemoryStore.ts
+++ b/app/src/features/context-memory/useMemoryStore.ts
@@ -1,0 +1,94 @@
+import { create } from 'zustand'
+import { nanoid } from 'nanoid'
+import { getDB, type MemoryBlock } from '@/lib/db'
+import { useFlowStore } from '@/store/flowStore'
+import { BLOCK_META } from '@/types/blocks'
+import type { BlockType } from '@/types/blocks'
+
+interface MemoryState {
+  blocks: MemoryBlock[]
+  isOpen: boolean
+  isLoaded: boolean
+  searchQuery: string
+  setOpen: (open: boolean) => void
+  setSearch: (q: string) => void
+  load: () => Promise<void>
+  create: (data: Omit<MemoryBlock, 'id' | 'createdAt' | 'usageCount' | 'lastUsedAt'>) => Promise<void>
+  remove: (id: string) => Promise<void>
+  inject: (block: MemoryBlock) => void
+  toggleFavorite: (id: string) => Promise<void>
+}
+
+export const useMemoryStore = create<MemoryState>((set, get) => ({
+  blocks: [],
+  isOpen: false,
+  isLoaded: false,
+  searchQuery: '',
+
+  setOpen: (isOpen) => {
+    set({ isOpen })
+    if (isOpen && !get().isLoaded) get().load()
+  },
+
+  setSearch: (searchQuery) => set({ searchQuery }),
+
+  load: async () => {
+    const db = await getDB()
+    const blocks = await db.getAll('memory_blocks')
+    set({ blocks, isLoaded: true })
+  },
+
+  create: async (data) => {
+    const block: MemoryBlock = {
+      ...data,
+      id: nanoid(),
+      createdAt: new Date().toISOString(),
+      usageCount: 0,
+      lastUsedAt: null,
+    }
+    const db = await getDB()
+    await db.put('memory_blocks', block)
+    set(state => ({ blocks: [...state.blocks, block] }))
+  },
+
+  remove: async (id) => {
+    const db = await getDB()
+    await db.delete('memory_blocks', id)
+    set(state => ({ blocks: state.blocks.filter(b => b.id !== id) }))
+  },
+
+  inject: (block) => {
+    const meta = BLOCK_META[block.blockType as BlockType]
+    if (!meta) return
+    const node = {
+      id: nanoid(),
+      type: 'block' as const,
+      position: { x: 100 + Math.random() * 200, y: 100 + Math.random() * 200 },
+      data: {
+        type: block.blockType as BlockType,
+        label: meta.label,
+        content: block.content,
+        description: meta.description,
+        summary: block.name,
+      },
+    }
+    useFlowStore.getState().addNode(node)
+    // Update usage count
+    const db_update = async () => {
+      const db = await getDB()
+      const updated = { ...block, usageCount: block.usageCount + 1, lastUsedAt: new Date().toISOString() }
+      await db.put('memory_blocks', updated)
+      set(state => ({ blocks: state.blocks.map(b => b.id === block.id ? updated : b) }))
+    }
+    db_update()
+  },
+
+  toggleFavorite: async (id) => {
+    const block = get().blocks.find(b => b.id === id)
+    if (!block) return
+    const updated = { ...block, isFavorite: !block.isFavorite }
+    const db = await getDB()
+    await db.put('memory_blocks', updated)
+    set(state => ({ blocks: state.blocks.map(b => b.id === id ? updated : b) }))
+  },
+}))

--- a/app/src/features/cost-estimator/CostPopover.tsx
+++ b/app/src/features/cost-estimator/CostPopover.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import { MODELS, estimateCost, formatCost, tokenBadgeColor } from './pricing'
+
+interface Props {
+  tokens: number
+}
+
+export default function CostPopover({ tokens }: Props) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="cost-popover-wrapper">
+      <button
+        className="token-badge token-badge--clickable"
+        style={{ color: tokenBadgeColor(tokens) }}
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+        title="Estimated cost per model"
+      >
+        ~{tokens.toLocaleString()} tokens
+      </button>
+
+      {open && (
+        <>
+          <div className="cost-popover-backdrop" onClick={() => setOpen(false)} />
+          <div className="cost-popover">
+            <div className="cost-popover-title">Estimated input cost</div>
+            <table className="cost-table">
+              <tbody>
+                {MODELS.map(m => (
+                  <tr key={m.id}>
+                    <td className="cost-table-model">{m.name}</td>
+                    <td className="cost-table-price">{formatCost(estimateCost(tokens, m))}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p className="cost-popover-note">Input cost only. Prices may vary.</p>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/app/src/features/cost-estimator/CostPopover.tsx
+++ b/app/src/features/cost-estimator/CostPopover.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useLocale } from '@/i18n/LocaleContext'
 import { MODELS, estimateCost, formatCost, tokenBadgeColor } from './pricing'
 
 interface Props {
@@ -7,6 +8,8 @@ interface Props {
 
 export default function CostPopover({ tokens }: Props) {
   const [open, setOpen] = useState(false)
+  const { t } = useLocale()
+  const tc = t.ide.cost
 
   return (
     <div className="cost-popover-wrapper">
@@ -15,7 +18,7 @@ export default function CostPopover({ tokens }: Props) {
         style={{ color: tokenBadgeColor(tokens) }}
         onClick={() => setOpen(o => !o)}
         aria-expanded={open}
-        title="Estimated cost per model"
+        title={tc.title}
       >
         ~{tokens.toLocaleString()} tokens
       </button>
@@ -24,7 +27,7 @@ export default function CostPopover({ tokens }: Props) {
         <>
           <div className="cost-popover-backdrop" onClick={() => setOpen(false)} />
           <div className="cost-popover">
-            <div className="cost-popover-title">Estimated input cost</div>
+            <div className="cost-popover-title">{tc.title}</div>
             <table className="cost-table">
               <tbody>
                 {MODELS.map(m => (
@@ -35,7 +38,7 @@ export default function CostPopover({ tokens }: Props) {
                 ))}
               </tbody>
             </table>
-            <p className="cost-popover-note">Input cost only. Prices may vary.</p>
+            <p className="cost-popover-note">{tc.note}</p>
           </div>
         </>
       )}

--- a/app/src/features/cost-estimator/pricing.ts
+++ b/app/src/features/cost-estimator/pricing.ts
@@ -1,0 +1,31 @@
+export interface ModelPricing {
+  id: string
+  name: string
+  inputPricePer1M: number
+  outputPricePer1M: number
+}
+
+export const MODELS: ModelPricing[] = [
+  { id: 'claude-3-5-sonnet', name: 'Claude 3.5 Sonnet', inputPricePer1M: 3.00,  outputPricePer1M: 15.00 },
+  { id: 'claude-3-5-haiku',  name: 'Claude 3.5 Haiku',  inputPricePer1M: 0.80,  outputPricePer1M:  4.00 },
+  { id: 'gpt-4o',            name: 'GPT-4o',            inputPricePer1M: 2.50,  outputPricePer1M: 10.00 },
+  { id: 'gpt-4o-mini',       name: 'GPT-4o mini',       inputPricePer1M: 0.15,  outputPricePer1M:  0.60 },
+  { id: 'gemini-1.5-pro',    name: 'Gemini 1.5 Pro',    inputPricePer1M: 1.25,  outputPricePer1M:  5.00 },
+  { id: 'gemini-1.5-flash',  name: 'Gemini 1.5 Flash',  inputPricePer1M: 0.075, outputPricePer1M:  0.30 },
+]
+
+export function estimateCost(tokens: number, model: ModelPricing): number {
+  return (tokens / 1_000_000) * model.inputPricePer1M
+}
+
+export function formatCost(usd: number): string {
+  if (usd < 0.0001) return '<$0.0001'
+  if (usd < 0.01)   return `$${usd.toFixed(4)}`
+  return `$${usd.toFixed(3)}`
+}
+
+export function tokenBadgeColor(tokens: number): string {
+  if (tokens < 1000) return '#22c55e'
+  if (tokens < 5000) return '#f59e0b'
+  return '#ef4444'
+}

--- a/app/src/features/critic/CriticPanel.tsx
+++ b/app/src/features/critic/CriticPanel.tsx
@@ -1,5 +1,6 @@
 import { X, Star, Loader, TrendingUp, TrendingDown, Lightbulb } from 'lucide-react'
 import { useCriticStore } from './useCriticStore'
+import { useLocale } from '@/i18n/LocaleContext'
 import RadarChart from './RadarChart'
 
 function gradeColor(grade: string) {
@@ -12,20 +13,22 @@ function gradeColor(grade: string) {
 
 export default function CriticPanel() {
   const { isOpen, isLoading, result, error, setOpen } = useCriticStore()
+  const { t } = useLocale()
+  const tc = t.ide.critic
 
   if (!isOpen) return null
 
   return (
     <>
       <div className="debugger-backdrop" onClick={() => setOpen(false)} />
-      <aside className="critic-panel" role="dialog" aria-label="AI Prompt Critic" aria-modal="true">
+      <aside className="critic-panel" role="dialog" aria-label={tc.title} aria-modal="true">
         <div className="debugger-header">
           <div className="debugger-brand">
             <Star size={15} />
-            <span className="debugger-title">AI Prompt Critic</span>
+            <span className="debugger-title">{tc.title}</span>
           </div>
-          <button className="make-close-btn" onClick={() => setOpen(false)} aria-label="Close">
-            <X size={14} />
+          <button className="ide-close-btn" onClick={() => setOpen(false)} aria-label={t.ide.close}>
+            <X size={15} />
           </button>
         </div>
 
@@ -33,7 +36,7 @@ export default function CriticPanel() {
           {isLoading && (
             <div className="debugger-loading">
               <Loader size={20} className="spin" />
-              <span>Evaluating your prompt…</span>
+              <span>{tc.loading}</span>
             </div>
           )}
 
@@ -51,7 +54,7 @@ export default function CriticPanel() {
                   <div className="critic-overall-score" style={{ color: gradeColor(result.grade) }}>
                     {result.overallScore.toFixed(1)} / 10
                   </div>
-                  <div className="debugger-section-label">Overall score</div>
+                  <div className="debugger-section-label">{tc.overallScore}</div>
                 </div>
                 <RadarChart dimensions={result.dimensions} />
               </div>
@@ -81,7 +84,7 @@ export default function CriticPanel() {
                 <div className="critic-section">
                   <div className="debugger-brand" style={{ marginBottom: 6 }}>
                     <TrendingUp size={12} style={{ color: '#22c55e' }} />
-                    <span className="debugger-section-label">Strengths</span>
+                    <span className="debugger-section-label">{tc.strengths}</span>
                   </div>
                   <ul className="critic-list critic-list--strengths">
                     {result.strengths.map((s, i) => <li key={i}>{s}</li>)}
@@ -93,7 +96,7 @@ export default function CriticPanel() {
                 <div className="critic-section">
                   <div className="debugger-brand" style={{ marginBottom: 6 }}>
                     <TrendingDown size={12} style={{ color: '#ef4444' }} />
-                    <span className="debugger-section-label">Weaknesses</span>
+                    <span className="debugger-section-label">{tc.weaknesses}</span>
                   </div>
                   <ul className="critic-list critic-list--weaknesses">
                     {result.weaknesses.map((w, i) => <li key={i}>{w}</li>)}
@@ -104,9 +107,7 @@ export default function CriticPanel() {
           )}
 
           {!isLoading && !result && !error && (
-            <div className="debugger-empty">
-              Click "Score" in the Result panel to evaluate your prompt.
-            </div>
+            <div className="debugger-empty">{tc.empty}</div>
           )}
         </div>
       </aside>

--- a/app/src/features/critic/CriticPanel.tsx
+++ b/app/src/features/critic/CriticPanel.tsx
@@ -70,7 +70,7 @@ export default function CriticPanel() {
                 {result.dimensions.map(d => (
                   <div key={d.name} className="critic-dim">
                     <div className="critic-dim-header">
-                      <span className="critic-dim-name">{d.name}</span>
+                      <span className="critic-dim-name">{tc.dimensions[d.name] ?? d.name}</span>
                       <span className="critic-dim-score" style={{ color: d.score >= 7 ? '#22c55e' : d.score >= 4 ? '#f59e0b' : '#ef4444' }}>
                         {d.score}/10
                       </span>

--- a/app/src/features/critic/CriticPanel.tsx
+++ b/app/src/features/critic/CriticPanel.tsx
@@ -1,0 +1,115 @@
+import { X, Star, Loader, TrendingUp, TrendingDown, Lightbulb } from 'lucide-react'
+import { useCriticStore } from './useCriticStore'
+import RadarChart from './RadarChart'
+
+function gradeColor(grade: string) {
+  if (grade === 'A') return '#22c55e'
+  if (grade === 'B') return '#84cc16'
+  if (grade === 'C') return '#f59e0b'
+  if (grade === 'D') return '#f97316'
+  return '#ef4444'
+}
+
+export default function CriticPanel() {
+  const { isOpen, isLoading, result, error, setOpen } = useCriticStore()
+
+  if (!isOpen) return null
+
+  return (
+    <>
+      <div className="debugger-backdrop" onClick={() => setOpen(false)} />
+      <aside className="critic-panel" role="dialog" aria-label="AI Prompt Critic" aria-modal="true">
+        <div className="debugger-header">
+          <div className="debugger-brand">
+            <Star size={15} />
+            <span className="debugger-title">AI Prompt Critic</span>
+          </div>
+          <button className="make-close-btn" onClick={() => setOpen(false)} aria-label="Close">
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="debugger-body">
+          {isLoading && (
+            <div className="debugger-loading">
+              <Loader size={20} className="spin" />
+              <span>Evaluating your prompt…</span>
+            </div>
+          )}
+
+          {error && !isLoading && (
+            <div className="debugger-error">{error}</div>
+          )}
+
+          {result && !isLoading && (
+            <>
+              <div className="critic-score-row">
+                <div className="critic-grade" style={{ color: gradeColor(result.grade) }}>
+                  {result.grade}
+                </div>
+                <div>
+                  <div className="critic-overall-score" style={{ color: gradeColor(result.grade) }}>
+                    {result.overallScore.toFixed(1)} / 10
+                  </div>
+                  <div className="debugger-section-label">Overall score</div>
+                </div>
+                <RadarChart dimensions={result.dimensions} />
+              </div>
+
+              {result.topRecommendation && (
+                <div className="critic-recommendation">
+                  <Lightbulb size={13} style={{ flexShrink: 0, color: '#f59e0b' }} />
+                  <span>{result.topRecommendation}</span>
+                </div>
+              )}
+
+              <div className="critic-feedback-grid">
+                {result.dimensions.map(d => (
+                  <div key={d.name} className="critic-dim">
+                    <div className="critic-dim-header">
+                      <span className="critic-dim-name">{d.name}</span>
+                      <span className="critic-dim-score" style={{ color: d.score >= 7 ? '#22c55e' : d.score >= 4 ? '#f59e0b' : '#ef4444' }}>
+                        {d.score}/10
+                      </span>
+                    </div>
+                    <p className="critic-dim-feedback">{d.feedback}</p>
+                  </div>
+                ))}
+              </div>
+
+              {result.strengths.length > 0 && (
+                <div className="critic-section">
+                  <div className="debugger-brand" style={{ marginBottom: 6 }}>
+                    <TrendingUp size={12} style={{ color: '#22c55e' }} />
+                    <span className="debugger-section-label">Strengths</span>
+                  </div>
+                  <ul className="critic-list critic-list--strengths">
+                    {result.strengths.map((s, i) => <li key={i}>{s}</li>)}
+                  </ul>
+                </div>
+              )}
+
+              {result.weaknesses.length > 0 && (
+                <div className="critic-section">
+                  <div className="debugger-brand" style={{ marginBottom: 6 }}>
+                    <TrendingDown size={12} style={{ color: '#ef4444' }} />
+                    <span className="debugger-section-label">Weaknesses</span>
+                  </div>
+                  <ul className="critic-list critic-list--weaknesses">
+                    {result.weaknesses.map((w, i) => <li key={i}>{w}</li>)}
+                  </ul>
+                </div>
+              )}
+            </>
+          )}
+
+          {!isLoading && !result && !error && (
+            <div className="debugger-empty">
+              Click "Score" in the Result panel to evaluate your prompt.
+            </div>
+          )}
+        </div>
+      </aside>
+    </>
+  )
+}

--- a/app/src/features/critic/RadarChart.tsx
+++ b/app/src/features/critic/RadarChart.tsx
@@ -1,0 +1,64 @@
+interface Dim { name: string; score: number }
+
+export default function RadarChart({ dimensions }: { dimensions: Dim[] }) {
+  const cx = 110, cy = 110, r = 80
+  const n = dimensions.length
+  if (n === 0) return null
+
+  const toPoint = (i: number, value: number) => {
+    const angle = (i / n) * 2 * Math.PI - Math.PI / 2
+    const dist = (value / 10) * r
+    return { x: cx + dist * Math.cos(angle), y: cy + dist * Math.sin(angle) }
+  }
+
+  const axisPoints = dimensions.map((_, i) => {
+    const angle = (i / n) * 2 * Math.PI - Math.PI / 2
+    return { x: cx + r * Math.cos(angle), y: cy + r * Math.sin(angle) }
+  })
+
+  const dataPoints = dimensions.map((d, i) => toPoint(i, d.score))
+  const dataPath = dataPoints.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ') + ' Z'
+
+  // Background grid (3 rings at 33%, 66%, 100%)
+  const gridPaths = [0.33, 0.66, 1].map(fraction => {
+    const pts = dimensions.map((_, i) => {
+      const angle = (i / n) * 2 * Math.PI - Math.PI / 2
+      const dist = fraction * r
+      return { x: cx + dist * Math.cos(angle), y: cy + dist * Math.sin(angle) }
+    })
+    return pts.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ') + ' Z'
+  })
+
+  return (
+    <svg width={220} height={220} viewBox="0 0 220 220" className="radar-chart">
+      {/* Grid rings */}
+      {gridPaths.map((d, i) => (
+        <path key={i} d={d} fill="none" stroke="var(--border, #333)" strokeWidth={1} opacity={0.5} />
+      ))}
+      {/* Axis lines */}
+      {axisPoints.map((p, i) => (
+        <line key={i} x1={cx} y1={cy} x2={p.x} y2={p.y} stroke="var(--border, #333)" strokeWidth={1} opacity={0.4} />
+      ))}
+      {/* Data area */}
+      <path d={dataPath} fill="rgba(255, 53, 112, 0.2)" stroke="#FF3570" strokeWidth={2} />
+      {/* Data points */}
+      {dataPoints.map((p, i) => (
+        <circle key={i} cx={p.x} cy={p.y} r={3} fill="#FF3570" />
+      ))}
+      {/* Labels */}
+      {dimensions.map((d, i) => {
+        const angle = (i / n) * 2 * Math.PI - Math.PI / 2
+        const labelR = r + 18
+        const lx = cx + labelR * Math.cos(angle)
+        const ly = cy + labelR * Math.sin(angle)
+        const anchor = lx < cx - 5 ? 'end' : lx > cx + 5 ? 'start' : 'middle'
+        return (
+          <text key={i} x={lx} y={ly} textAnchor={anchor} dominantBaseline="middle"
+            fontSize={9} fill="var(--text-dim, #888)" style={{ userSelect: 'none' }}>
+            {d.name}
+          </text>
+        )
+      })}
+    </svg>
+  )
+}

--- a/app/src/features/critic/types.ts
+++ b/app/src/features/critic/types.ts
@@ -1,0 +1,14 @@
+export interface CriticDimension {
+  name: string
+  score: number
+  feedback: string
+}
+
+export interface CriticResult {
+  overallScore: number
+  grade: 'A' | 'B' | 'C' | 'D' | 'F'
+  dimensions: CriticDimension[]
+  strengths: string[]
+  weaknesses: string[]
+  topRecommendation: string
+}

--- a/app/src/features/critic/useCriticStore.ts
+++ b/app/src/features/critic/useCriticStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand'
+import type { CriticResult } from './types'
+
+interface CriticState {
+  isOpen: boolean
+  isLoading: boolean
+  result: CriticResult | null
+  error: string | null
+  setOpen: (open: boolean) => void
+  setLoading: (loading: boolean) => void
+  setResult: (result: CriticResult | null) => void
+  setError: (error: string | null) => void
+}
+
+export const useCriticStore = create<CriticState>((set) => ({
+  isOpen: false,
+  isLoading: false,
+  result: null,
+  error: null,
+  setOpen: (isOpen) => set({ isOpen }),
+  setLoading: (isLoading) => set({ isLoading }),
+  setResult: (result) => set({ result }),
+  setError: (error) => set({ error }),
+}))

--- a/app/src/features/debugger/DebuggerPanel.tsx
+++ b/app/src/features/debugger/DebuggerPanel.tsx
@@ -1,5 +1,6 @@
 import { X, AlertCircle, AlertTriangle, Info, CheckCircle, Loader, Wand2 } from 'lucide-react'
 import { useDebuggerStore } from './useDebuggerStore'
+import { useLocale } from '@/i18n/LocaleContext'
 import type { IssueSeverity } from './types'
 
 function severityIcon(s: IssueSeverity) {
@@ -20,20 +21,22 @@ interface Props {
 
 export default function DebuggerPanel({ onApplyFix }: Props) {
   const { isOpen, isLoading, result, error, setOpen } = useDebuggerStore()
+  const { t } = useLocale()
+  const td = t.ide.debugger
 
   if (!isOpen) return null
 
   return (
     <>
       <div className="debugger-backdrop" onClick={() => setOpen(false)} />
-      <aside className="debugger-panel" role="dialog" aria-label="Prompt Debugger" aria-modal="true">
+      <aside className="debugger-panel" role="dialog" aria-label={td.title} aria-modal="true">
         <div className="debugger-header">
           <div className="debugger-brand">
             <AlertCircle size={15} />
-            <span className="debugger-title">Prompt Debugger</span>
+            <span className="debugger-title">{td.title}</span>
           </div>
-          <button className="make-close-btn" onClick={() => setOpen(false)} aria-label="Close">
-            <X size={14} />
+          <button className="ide-close-btn" onClick={() => setOpen(false)} aria-label={t.ide.close}>
+            <X size={15} />
           </button>
         </div>
 
@@ -41,7 +44,7 @@ export default function DebuggerPanel({ onApplyFix }: Props) {
           {isLoading && (
             <div className="debugger-loading">
               <Loader size={20} className="spin" />
-              <span>Analyzing your prompt…</span>
+              <span>{td.loading}</span>
             </div>
           )}
 
@@ -54,17 +57,17 @@ export default function DebuggerPanel({ onApplyFix }: Props) {
           {result && !isLoading && (
             <>
               <div className="debugger-score-row">
-                <div className="debugger-score-gauge" style={{ '--score-color': scoreColor(result.score) } as React.CSSProperties}>
+                <div className="debugger-score-gauge">
                   <span className="debugger-score-number" style={{ color: scoreColor(result.score) }}>
                     {result.score}
                   </span>
-                  <span className="debugger-score-label">/ 100</span>
+                  <span className="debugger-score-label">{td.scoreLabel}</span>
                 </div>
                 <div className="debugger-token-delta">
-                  <span>Before: {result.tokensBefore} words</span>
+                  <span>{td.wordsBefore.replace('{n}', String(result.tokensBefore))}</span>
                   {result.tokensAfter < result.tokensBefore && (
                     <span className="debugger-token-saved">
-                      Fix saves ~{result.tokensBefore - result.tokensAfter} words
+                      {td.wordsSaved.replace('{n}', String(result.tokensBefore - result.tokensAfter))}
                     </span>
                   )}
                 </div>
@@ -73,14 +76,14 @@ export default function DebuggerPanel({ onApplyFix }: Props) {
               {result.issues.length === 0 ? (
                 <div className="debugger-no-issues">
                   <CheckCircle size={16} style={{ color: '#22c55e' }} />
-                  <span>No issues detected — great prompt!</span>
+                  <span>{td.noIssues}</span>
                 </div>
               ) : (
                 <ul className="debugger-issues">
                   {result.issues.map((issue) => (
                     <li key={issue.id} className={`debugger-issue debugger-issue--${issue.severity}`}>
                       <div className="debugger-issue-header">
-                        {severityIcon(issue.severity)}
+                        {severityIcon(issue.severity as IssueSeverity)}
                         <span className="debugger-issue-message">{issue.message}</span>
                       </div>
                       <p className="debugger-issue-suggestion">{issue.suggestion}</p>
@@ -91,7 +94,7 @@ export default function DebuggerPanel({ onApplyFix }: Props) {
 
               {result.improvements.length > 0 && (
                 <div className="debugger-improvements">
-                  <span className="debugger-section-label">Suggestions</span>
+                  <span className="debugger-section-label">{td.suggestions}</span>
                   <ul>
                     {result.improvements.map((imp, i) => (
                       <li key={i}>{imp}</li>
@@ -104,15 +107,13 @@ export default function DebuggerPanel({ onApplyFix }: Props) {
                 className="debugger-apply-btn"
                 onClick={() => { onApplyFix(result.fixedPrompt); setOpen(false) }}
               >
-                <Wand2 size={13} /> Apply Fixed Prompt
+                <Wand2 size={13} /> {td.applyFix}
               </button>
             </>
           )}
 
           {!isLoading && !result && !error && (
-            <div className="debugger-empty">
-              Click "Debug" in the Result panel to analyze your prompt.
-            </div>
+            <div className="debugger-empty">{td.empty}</div>
           )}
         </div>
       </aside>

--- a/app/src/features/debugger/DebuggerPanel.tsx
+++ b/app/src/features/debugger/DebuggerPanel.tsx
@@ -1,0 +1,121 @@
+import { X, AlertCircle, AlertTriangle, Info, CheckCircle, Loader, Wand2 } from 'lucide-react'
+import { useDebuggerStore } from './useDebuggerStore'
+import type { IssueSeverity } from './types'
+
+function severityIcon(s: IssueSeverity) {
+  if (s === 'error')   return <AlertCircle size={13} style={{ color: 'var(--error, #ef4444)' }} />
+  if (s === 'warning') return <AlertTriangle size={13} style={{ color: '#f59e0b' }} />
+  return <Info size={13} style={{ color: '#60a5fa' }} />
+}
+
+function scoreColor(score: number) {
+  if (score >= 70) return '#22c55e'
+  if (score >= 40) return '#f59e0b'
+  return '#ef4444'
+}
+
+interface Props {
+  onApplyFix: (fixedPrompt: string) => void
+}
+
+export default function DebuggerPanel({ onApplyFix }: Props) {
+  const { isOpen, isLoading, result, error, setOpen } = useDebuggerStore()
+
+  if (!isOpen) return null
+
+  return (
+    <>
+      <div className="debugger-backdrop" onClick={() => setOpen(false)} />
+      <aside className="debugger-panel" role="dialog" aria-label="Prompt Debugger" aria-modal="true">
+        <div className="debugger-header">
+          <div className="debugger-brand">
+            <AlertCircle size={15} />
+            <span className="debugger-title">Prompt Debugger</span>
+          </div>
+          <button className="make-close-btn" onClick={() => setOpen(false)} aria-label="Close">
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="debugger-body">
+          {isLoading && (
+            <div className="debugger-loading">
+              <Loader size={20} className="spin" />
+              <span>Analyzing your prompt…</span>
+            </div>
+          )}
+
+          {error && !isLoading && (
+            <div className="debugger-error">
+              <AlertCircle size={14} /> {error}
+            </div>
+          )}
+
+          {result && !isLoading && (
+            <>
+              <div className="debugger-score-row">
+                <div className="debugger-score-gauge" style={{ '--score-color': scoreColor(result.score) } as React.CSSProperties}>
+                  <span className="debugger-score-number" style={{ color: scoreColor(result.score) }}>
+                    {result.score}
+                  </span>
+                  <span className="debugger-score-label">/ 100</span>
+                </div>
+                <div className="debugger-token-delta">
+                  <span>Before: {result.tokensBefore} words</span>
+                  {result.tokensAfter < result.tokensBefore && (
+                    <span className="debugger-token-saved">
+                      Fix saves ~{result.tokensBefore - result.tokensAfter} words
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {result.issues.length === 0 ? (
+                <div className="debugger-no-issues">
+                  <CheckCircle size={16} style={{ color: '#22c55e' }} />
+                  <span>No issues detected — great prompt!</span>
+                </div>
+              ) : (
+                <ul className="debugger-issues">
+                  {result.issues.map((issue) => (
+                    <li key={issue.id} className={`debugger-issue debugger-issue--${issue.severity}`}>
+                      <div className="debugger-issue-header">
+                        {severityIcon(issue.severity)}
+                        <span className="debugger-issue-message">{issue.message}</span>
+                      </div>
+                      <p className="debugger-issue-suggestion">{issue.suggestion}</p>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {result.improvements.length > 0 && (
+                <div className="debugger-improvements">
+                  <span className="debugger-section-label">Suggestions</span>
+                  <ul>
+                    {result.improvements.map((imp, i) => (
+                      <li key={i}>{imp}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <button
+                className="debugger-apply-btn"
+                onClick={() => { onApplyFix(result.fixedPrompt); setOpen(false) }}
+              >
+                <Wand2 size={13} /> Apply Fixed Prompt
+              </button>
+            </>
+          )}
+
+          {!isLoading && !result && !error && (
+            <div className="debugger-empty">
+              Click "Debug" in the Result panel to analyze your prompt.
+            </div>
+          )}
+        </div>
+      </aside>
+    </>
+  )
+}

--- a/app/src/features/debugger/types.ts
+++ b/app/src/features/debugger/types.ts
@@ -1,0 +1,19 @@
+export type IssueSeverity = 'error' | 'warning' | 'info'
+
+export interface DebugIssue {
+  id: string
+  severity: IssueSeverity
+  category: string
+  message: string
+  location?: string
+  suggestion: string
+}
+
+export interface DebugResult {
+  issues: DebugIssue[]
+  score: number
+  fixedPrompt: string
+  improvements: string[]
+  tokensBefore: number
+  tokensAfter: number
+}

--- a/app/src/features/debugger/useDebuggerStore.ts
+++ b/app/src/features/debugger/useDebuggerStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand'
+import type { DebugResult } from './types'
+
+interface DebuggerState {
+  isOpen: boolean
+  isLoading: boolean
+  result: DebugResult | null
+  error: string | null
+  setOpen: (open: boolean) => void
+  setLoading: (loading: boolean) => void
+  setResult: (result: DebugResult | null) => void
+  setError: (error: string | null) => void
+}
+
+export const useDebuggerStore = create<DebuggerState>((set) => ({
+  isOpen: false,
+  isLoading: false,
+  result: null,
+  error: null,
+  setOpen: (isOpen) => set({ isOpen }),
+  setLoading: (isLoading) => set({ isLoading }),
+  setResult: (result) => set({ result }),
+  setError: (error) => set({ error }),
+}))

--- a/app/src/features/system-prompt/SystemPromptModal.tsx
+++ b/app/src/features/system-prompt/SystemPromptModal.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import { X, Wand2, Copy, CheckCircle, Loader } from 'lucide-react'
+import { useSystemPromptStore } from './useSystemPromptStore'
+
+const SECTION_COLORS: Record<string, string> = {
+  SYSTEM:        '#c084fc',
+  ROLE:          '#93c5fd',
+  CONTEXT:       '#94a3b8',
+  OBJECTIVE:     '#fbbf24',
+  CONSTRAINTS:   '#fb7185',
+  OUTPUT_FORMAT: '#ff6b9d',
+}
+
+interface Props {
+  onApplyToCanvas: (sections: Array<{ name: string; content: string }>) => void
+}
+
+export default function SystemPromptModal({ onApplyToCanvas }: Props) {
+  const { isOpen, isLoading, result, error, editedSections, setOpen, updateSection } = useSystemPromptStore()
+  const [copied, setCopied] = useState(false)
+
+  if (!isOpen) return null
+
+  const handleCopy = () => {
+    const full = editedSections.map(s => `## ${s.name}\n${s.content}`).join('\n\n')
+    navigator.clipboard.writeText(full).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
+  return (
+    <div className="compressor-overlay" role="dialog" aria-modal="true" aria-label="System Prompt Generator">
+      <div className="compressor-backdrop" onClick={() => setOpen(false)} />
+      <div className="compressor-modal" style={{ maxWidth: 700 }}>
+        <div className="compressor-header">
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <Wand2 size={15} />
+            <span className="compressor-title">System Prompt Generator</span>
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            {result && !isLoading && (
+              <>
+                <button className="btn btn-secondary export-btn" style={{ fontSize: 11 }} onClick={handleCopy}>
+                  {copied ? <><CheckCircle size={11} /> Copied!</> : <><Copy size={11} /> Copy all</>}
+                </button>
+                <button className="debugger-apply-btn" style={{ margin: 0 }} onClick={() => { onApplyToCanvas(editedSections); setOpen(false) }}>
+                  Apply to canvas
+                </button>
+              </>
+            )}
+            <button className="make-close-btn" onClick={() => setOpen(false)} aria-label="Close">
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+
+        {isLoading && (
+          <div className="debugger-loading" style={{ padding: 40 }}>
+            <Loader size={20} className="spin" />
+            <span>Generating system prompt…</span>
+          </div>
+        )}
+
+        {error && !isLoading && (
+          <div className="debugger-error" style={{ margin: 16 }}>{error}</div>
+        )}
+
+        {editedSections.length > 0 && !isLoading && (
+          <div className="sysprompt-sections">
+            {editedSections.map(s => (
+              <div key={s.name} className="sysprompt-section">
+                <div className="sysprompt-section-label" style={{ '--section-color': SECTION_COLORS[s.name] ?? '#888' } as React.CSSProperties}>
+                  {s.name}
+                </div>
+                <textarea
+                  className="sysprompt-textarea"
+                  value={s.content}
+                  onChange={e => updateSection(s.name, e.target.value)}
+                  rows={4}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!isLoading && !result && !error && (
+          <div className="debugger-empty" style={{ padding: 32 }}>
+            Click "Generate System Prompt" in the Prompt input to get started.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/src/features/system-prompt/SystemPromptModal.tsx
+++ b/app/src/features/system-prompt/SystemPromptModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { X, Wand2, Copy, CheckCircle, Loader } from 'lucide-react'
 import { useSystemPromptStore } from './useSystemPromptStore'
+import { useLocale } from '@/i18n/LocaleContext'
 
 const SECTION_COLORS: Record<string, string> = {
   SYSTEM:        '#c084fc',
@@ -17,6 +18,8 @@ interface Props {
 
 export default function SystemPromptModal({ onApplyToCanvas }: Props) {
   const { isOpen, isLoading, result, error, editedSections, setOpen, updateSection } = useSystemPromptStore()
+  const { t } = useLocale()
+  const ts = t.ide.systemPrompt
   const [copied, setCopied] = useState(false)
 
   if (!isOpen) return null
@@ -30,27 +33,30 @@ export default function SystemPromptModal({ onApplyToCanvas }: Props) {
   }
 
   return (
-    <div className="compressor-overlay" role="dialog" aria-modal="true" aria-label="System Prompt Generator">
+    <div className="compressor-overlay" role="dialog" aria-modal="true" aria-label={ts.title}>
       <div className="compressor-backdrop" onClick={() => setOpen(false)} />
       <div className="compressor-modal" style={{ maxWidth: 700 }}>
         <div className="compressor-header">
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <Wand2 size={15} />
-            <span className="compressor-title">System Prompt Generator</span>
+            <span className="compressor-title">{ts.title}</span>
           </div>
-          <div style={{ display: 'flex', gap: 8 }}>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
             {result && !isLoading && (
               <>
-                <button className="btn btn-secondary export-btn" style={{ fontSize: 11 }} onClick={handleCopy}>
-                  {copied ? <><CheckCircle size={11} /> Copied!</> : <><Copy size={11} /> Copy all</>}
+                <button className="ide-action-btn" onClick={handleCopy}>
+                  {copied
+                    ? <><CheckCircle size={11} /> {ts.copied}</>
+                    : <><Copy size={11} /> {ts.copyAll}</>
+                  }
                 </button>
                 <button className="debugger-apply-btn" style={{ margin: 0 }} onClick={() => { onApplyToCanvas(editedSections); setOpen(false) }}>
-                  Apply to canvas
+                  {ts.apply}
                 </button>
               </>
             )}
-            <button className="make-close-btn" onClick={() => setOpen(false)} aria-label="Close">
-              <X size={14} />
+            <button className="ide-close-btn" onClick={() => setOpen(false)} aria-label={t.ide.close}>
+              <X size={15} />
             </button>
           </div>
         </div>
@@ -58,7 +64,7 @@ export default function SystemPromptModal({ onApplyToCanvas }: Props) {
         {isLoading && (
           <div className="debugger-loading" style={{ padding: 40 }}>
             <Loader size={20} className="spin" />
-            <span>Generating system prompt…</span>
+            <span>{ts.loading}</span>
           </div>
         )}
 
@@ -85,9 +91,7 @@ export default function SystemPromptModal({ onApplyToCanvas }: Props) {
         )}
 
         {!isLoading && !result && !error && (
-          <div className="debugger-empty" style={{ padding: 32 }}>
-            Click "Generate System Prompt" in the Prompt input to get started.
-          </div>
+          <div className="debugger-empty" style={{ padding: 32 }}>{ts.empty}</div>
         )}
       </div>
     </div>

--- a/app/src/features/system-prompt/types.ts
+++ b/app/src/features/system-prompt/types.ts
@@ -1,0 +1,10 @@
+export interface SystemSection {
+  name: string
+  content: string
+}
+
+export interface SystemPromptResult {
+  sections: SystemSection[]
+  fullPrompt: string
+  totalTokens: number
+}

--- a/app/src/features/system-prompt/useSystemPromptStore.ts
+++ b/app/src/features/system-prompt/useSystemPromptStore.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand'
+import type { SystemPromptResult, SystemSection } from './types'
+
+interface SystemPromptState {
+  isOpen: boolean
+  isLoading: boolean
+  result: SystemPromptResult | null
+  error: string | null
+  editedSections: SystemSection[]
+  setOpen: (open: boolean) => void
+  setLoading: (loading: boolean) => void
+  setResult: (result: SystemPromptResult | null) => void
+  setError: (error: string | null) => void
+  updateSection: (name: string, content: string) => void
+}
+
+export const useSystemPromptStore = create<SystemPromptState>((set) => ({
+  isOpen: false,
+  isLoading: false,
+  result: null,
+  error: null,
+  editedSections: [],
+  setOpen: (isOpen) => set({ isOpen }),
+  setLoading: (isLoading) => set({ isLoading }),
+  setResult: (result) => set({ result, editedSections: result?.sections ?? [] }),
+  setError: (error) => set({ error }),
+  updateSection: (name, content) =>
+    set(state => ({
+      editedSections: state.editedSections.map(s => s.name === name ? { ...s, content } : s)
+    })),
+}))

--- a/app/src/features/versioning/VersionHistory.tsx
+++ b/app/src/features/versioning/VersionHistory.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react'
+import { X, History, RotateCcw, GitCompare, Trash2, Save, Clock } from 'lucide-react'
+import { useVersionStore } from './useVersionStore'
+import type { PromptVersion } from '@/lib/db'
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
+
+interface Props {
+  projectId: string
+}
+
+export default function VersionHistory({ projectId }: Props) {
+  const { versions, isOpen, diffView, setOpen, save, rollback, showDiff, closeDiff, remove } = useVersionStore()
+  const [message, setMessage] = useState('')
+  const [compareA, setCompareA] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  if (!isOpen) return null
+
+  const handleSave = async () => {
+    setSaving(true)
+    await save(projectId, message.trim() || undefined)
+    setMessage('')
+    setSaving(false)
+  }
+
+  const handleCompareSelect = (id: string) => {
+    if (!compareA) {
+      setCompareA(id)
+    } else {
+      showDiff(compareA, id)
+      setCompareA(null)
+    }
+  }
+
+  return (
+    <>
+      <div className="debugger-backdrop" onClick={() => { setOpen(false); closeDiff() }} />
+      <aside className="version-panel" role="dialog" aria-label="Version History" aria-modal="true">
+        <div className="debugger-header">
+          <div className="debugger-brand">
+            <History size={15} />
+            <span className="debugger-title">Version History</span>
+          </div>
+          <button className="make-close-btn" onClick={() => { setOpen(false); closeDiff() }} aria-label="Close">
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="version-save-row">
+          <input
+            className="make-webhook-input"
+            style={{ flex: 1, fontSize: 12 }}
+            placeholder="Version message (optional)"
+            value={message}
+            onChange={e => setMessage(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && handleSave()}
+          />
+          <button className="debugger-apply-btn" style={{ margin: 0, whiteSpace: 'nowrap' }} onClick={handleSave} disabled={saving}>
+            <Save size={12} /> {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+
+        {compareA && (
+          <div className="version-compare-hint">
+            <GitCompare size={12} /> Select second version to compare
+          </div>
+        )}
+
+        {diffView && (
+          <div className="version-diff">
+            <div className="version-diff-header">
+              <span className="debugger-section-label">Diff</span>
+              <button className="make-close-btn" onClick={closeDiff}><X size={12} /></button>
+            </div>
+            <div className="version-diff-body">
+              {diffView.lines.map((line, i) => (
+                <div key={i} className={`diff-line diff-line--${line.type}`}>
+                  <span className="diff-line-num">{line.lineNumberBefore ?? ' '}</span>
+                  <span className="diff-line-num">{line.lineNumberAfter ?? ' '}</span>
+                  <span className="diff-line-marker">
+                    {line.type === 'added' ? '+' : line.type === 'removed' ? '-' : ' '}
+                  </span>
+                  <span className="diff-line-content">{line.content}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="version-list">
+          {versions.length === 0 && (
+            <div className="debugger-empty">No saved versions yet.</div>
+          )}
+          {versions.map((v: PromptVersion) => (
+            <div key={v.id} className={`version-item${compareA === v.id ? ' version-item--selected' : ''}`}>
+              <div className="version-item-header">
+                <span className="version-item-label">{v.label}</span>
+                <span className="version-item-time"><Clock size={10} /> {timeAgo(v.createdAt)}</span>
+              </div>
+              {v.tokenCount > 0 && (
+                <span className="version-item-tokens">{v.tokenCount} tokens</span>
+              )}
+              <div className="version-item-actions">
+                <button className="btn btn-secondary export-btn" style={{ fontSize: 10, padding: '2px 6px' }} title="Rollback to this version" onClick={() => rollback(v)}>
+                  <RotateCcw size={10} /> Restore
+                </button>
+                <button className="btn btn-secondary export-btn" style={{ fontSize: 10, padding: '2px 6px' }} title="Compare" onClick={() => handleCompareSelect(v.id)}>
+                  <GitCompare size={10} /> Compare
+                </button>
+                <button className="make-close-btn" title="Delete version" onClick={() => remove(v.id)}>
+                  <Trash2 size={11} />
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </aside>
+    </>
+  )
+}

--- a/app/src/features/versioning/VersionHistory.tsx
+++ b/app/src/features/versioning/VersionHistory.tsx
@@ -1,16 +1,17 @@
 import { useState } from 'react'
 import { X, History, RotateCcw, GitCompare, Trash2, Save, Clock } from 'lucide-react'
 import { useVersionStore } from './useVersionStore'
+import { useLocale } from '@/i18n/LocaleContext'
 import type { PromptVersion } from '@/lib/db'
 
-function timeAgo(iso: string): string {
+function timeAgo(iso: string, tv: typeof import('@/i18n/translations').translations['en']['ide']['versioning']): string {
   const diff = Date.now() - new Date(iso).getTime()
   const mins = Math.floor(diff / 60000)
-  if (mins < 1) return 'just now'
-  if (mins < 60) return `${mins}m ago`
+  if (mins < 1) return tv.justNow
+  if (mins < 60) return tv.minsAgo.replace('{n}', String(mins))
   const hours = Math.floor(mins / 60)
-  if (hours < 24) return `${hours}h ago`
-  return `${Math.floor(hours / 24)}d ago`
+  if (hours < 24) return tv.hoursAgo.replace('{n}', String(hours))
+  return tv.daysAgo.replace('{n}', String(Math.floor(hours / 24)))
 }
 
 interface Props {
@@ -19,6 +20,8 @@ interface Props {
 
 export default function VersionHistory({ projectId }: Props) {
   const { versions, isOpen, diffView, setOpen, save, rollback, showDiff, closeDiff, remove } = useVersionStore()
+  const { t } = useLocale()
+  const tv = t.ide.versioning
   const [message, setMessage] = useState('')
   const [compareA, setCompareA] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
@@ -44,14 +47,14 @@ export default function VersionHistory({ projectId }: Props) {
   return (
     <>
       <div className="debugger-backdrop" onClick={() => { setOpen(false); closeDiff() }} />
-      <aside className="version-panel" role="dialog" aria-label="Version History" aria-modal="true">
+      <aside className="version-panel" role="dialog" aria-label={tv.title} aria-modal="true">
         <div className="debugger-header">
           <div className="debugger-brand">
             <History size={15} />
-            <span className="debugger-title">Version History</span>
+            <span className="debugger-title">{tv.title}</span>
           </div>
-          <button className="make-close-btn" onClick={() => { setOpen(false); closeDiff() }} aria-label="Close">
-            <X size={14} />
+          <button className="ide-close-btn" onClick={() => { setOpen(false); closeDiff() }} aria-label={t.ide.close}>
+            <X size={15} />
           </button>
         </div>
 
@@ -59,27 +62,29 @@ export default function VersionHistory({ projectId }: Props) {
           <input
             className="make-webhook-input"
             style={{ flex: 1, fontSize: 12 }}
-            placeholder="Version message (optional)"
+            placeholder={tv.messagePlaceholder}
             value={message}
             onChange={e => setMessage(e.target.value)}
             onKeyDown={e => e.key === 'Enter' && handleSave()}
           />
           <button className="debugger-apply-btn" style={{ margin: 0, whiteSpace: 'nowrap' }} onClick={handleSave} disabled={saving}>
-            <Save size={12} /> {saving ? 'Saving…' : 'Save'}
+            <Save size={12} /> {saving ? tv.saving : tv.save}
           </button>
         </div>
 
         {compareA && (
           <div className="version-compare-hint">
-            <GitCompare size={12} /> Select second version to compare
+            <GitCompare size={12} /> {tv.compareHint}
           </div>
         )}
 
         {diffView && (
           <div className="version-diff">
             <div className="version-diff-header">
-              <span className="debugger-section-label">Diff</span>
-              <button className="make-close-btn" onClick={closeDiff}><X size={12} /></button>
+              <span className="debugger-section-label">{tv.diff}</span>
+              <button className="ide-close-btn" style={{ width: 26, height: 26 }} onClick={closeDiff}>
+                <X size={12} />
+              </button>
             </div>
             <div className="version-diff-body">
               {diffView.lines.map((line, i) => (
@@ -98,26 +103,26 @@ export default function VersionHistory({ projectId }: Props) {
 
         <div className="version-list">
           {versions.length === 0 && (
-            <div className="debugger-empty">No saved versions yet.</div>
+            <div className="debugger-empty">{tv.noVersions}</div>
           )}
           {versions.map((v: PromptVersion) => (
             <div key={v.id} className={`version-item${compareA === v.id ? ' version-item--selected' : ''}`}>
               <div className="version-item-header">
                 <span className="version-item-label">{v.label}</span>
-                <span className="version-item-time"><Clock size={10} /> {timeAgo(v.createdAt)}</span>
+                <span className="version-item-time"><Clock size={10} /> {timeAgo(v.createdAt, tv)}</span>
               </div>
               {v.tokenCount > 0 && (
                 <span className="version-item-tokens">{v.tokenCount} tokens</span>
               )}
               <div className="version-item-actions">
-                <button className="btn btn-secondary export-btn" style={{ fontSize: 10, padding: '2px 6px' }} title="Rollback to this version" onClick={() => rollback(v)}>
-                  <RotateCcw size={10} /> Restore
+                <button className="ide-action-btn" title={tv.restore} onClick={() => rollback(v)}>
+                  <RotateCcw size={10} /> {tv.restore}
                 </button>
-                <button className="btn btn-secondary export-btn" style={{ fontSize: 10, padding: '2px 6px' }} title="Compare" onClick={() => handleCompareSelect(v.id)}>
-                  <GitCompare size={10} /> Compare
+                <button className="ide-action-btn" title={tv.compare} onClick={() => handleCompareSelect(v.id)}>
+                  <GitCompare size={10} /> {tv.compare}
                 </button>
-                <button className="make-close-btn" title="Delete version" onClick={() => remove(v.id)}>
-                  <Trash2 size={11} />
+                <button className="ide-action-btn ide-action-btn--danger" title="Delete" onClick={() => remove(v.id)}>
+                  <Trash2 size={10} />
                 </button>
               </div>
             </div>

--- a/app/src/features/versioning/useVersionStore.ts
+++ b/app/src/features/versioning/useVersionStore.ts
@@ -1,0 +1,80 @@
+import { create } from 'zustand'
+import { nanoid } from 'nanoid'
+import { getDB, type PromptVersion } from '@/lib/db'
+import { useFlowStore } from '@/store/flowStore'
+import { computeLineDiff, type DiffLine } from '@/lib/diff'
+
+interface VersionState {
+  versions: PromptVersion[]
+  isOpen: boolean
+  isLoaded: boolean
+  diffView: { idA: string; idB: string; lines: DiffLine[] } | null
+  setOpen: (open: boolean) => void
+  load: (projectId: string) => Promise<void>
+  save: (projectId: string, message?: string) => Promise<void>
+  rollback: (version: PromptVersion) => void
+  showDiff: (idA: string, idB: string) => void
+  closeDiff: () => void
+  remove: (id: string) => Promise<void>
+}
+
+export const useVersionStore = create<VersionState>((set, get) => ({
+  versions: [],
+  isOpen: false,
+  isLoaded: false,
+  diffView: null,
+
+  setOpen: (isOpen) => set({ isOpen }),
+
+  load: async (projectId) => {
+    const db = await getDB()
+    const all = await db.getAllFromIndex('versions', 'by-project', projectId)
+    all.sort((a, b) => b.version - a.version)
+    set({ versions: all, isLoaded: true })
+  },
+
+  save: async (projectId, message) => {
+    const { nodes, edges, rawPrompt, compiledPrompt } = useFlowStore.getState()
+    const existing = get().versions.filter(v => v.projectId === projectId)
+    const versionNum = (existing[0]?.version ?? 0) + 1
+    const version: PromptVersion = {
+      id: nanoid(),
+      projectId,
+      version: versionNum,
+      label: message ?? `v${versionNum}`,
+      message: message ?? '',
+      prompt: rawPrompt,
+      nodes: JSON.parse(JSON.stringify(nodes)),
+      edges: JSON.parse(JSON.stringify(edges)),
+      tokenCount: compiledPrompt?.tokenEstimate ?? 0,
+      createdAt: new Date().toISOString(),
+      tags: [],
+    }
+    const db = await getDB()
+    await db.put('versions', version)
+    set(state => ({ versions: [version, ...state.versions] }))
+  },
+
+  rollback: (version) => {
+    const store = useFlowStore.getState()
+    store.setNodes(version.nodes)
+    store.setEdges(version.edges)
+  },
+
+  showDiff: (idA, idB) => {
+    const versions = get().versions
+    const vA = versions.find(v => v.id === idA)
+    const vB = versions.find(v => v.id === idB)
+    if (!vA || !vB) return
+    const lines = computeLineDiff(vA.prompt, vB.prompt)
+    set({ diffView: { idA, idB, lines } })
+  },
+
+  closeDiff: () => set({ diffView: null }),
+
+  remove: async (id) => {
+    const db = await getDB()
+    await db.delete('versions', id)
+    set(state => ({ versions: state.versions.filter(v => v.id !== id) }))
+  },
+}))

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -264,7 +264,15 @@
       "empty": "Click \"Score\" in the Result panel to evaluate your prompt.",
       "overallScore": "Overall score",
       "strengths": "Strengths",
-      "weaknesses": "Weaknesses"
+      "weaknesses": "Weaknesses",
+      "dimensions": {
+        "clarity": "Clarity",
+        "specificity": "Specificity",
+        "structure": "Structure",
+        "examples": "Examples",
+        "constraints": "Constraints",
+        "format": "Format"
+      }
     },
     "systemPrompt": {
       "title": "System Prompt Generator",

--- a/app/src/i18n/en.json
+++ b/app/src/i18n/en.json
@@ -231,6 +231,89 @@
     "export": "Export projects",
     "import": "Import projects"
   },
+  "ide": {
+    "close": "Close",
+    "debugger": {
+      "title": "Prompt Debugger",
+      "loading": "Analyzing your prompt…",
+      "empty": "Click \"Debug\" in the Result panel to analyze your prompt.",
+      "noIssues": "No issues detected — great prompt!",
+      "scoreLabel": "/ 100",
+      "wordsBefore": "Before: {n} words",
+      "wordsSaved": "Fix saves ~{n} words",
+      "suggestions": "Suggestions",
+      "applyFix": "Apply Fixed Prompt"
+    },
+    "compressor": {
+      "title": "Prompt Compressor",
+      "loading": "Compressing…",
+      "targetReduction": "Target reduction:",
+      "before": "Before",
+      "after": "After",
+      "saved": "Saved",
+      "words": "words",
+      "original": "Original",
+      "compressed": "Compressed prompt",
+      "changes": "Changes",
+      "noChanges": "(no changes)",
+      "apply": "Apply Compressed Prompt"
+    },
+    "critic": {
+      "title": "AI Prompt Critic",
+      "loading": "Evaluating your prompt…",
+      "empty": "Click \"Score\" in the Result panel to evaluate your prompt.",
+      "overallScore": "Overall score",
+      "strengths": "Strengths",
+      "weaknesses": "Weaknesses"
+    },
+    "systemPrompt": {
+      "title": "System Prompt Generator",
+      "loading": "Generating system prompt…",
+      "empty": "Click \"System Prompt\" in the Prompt input to get started.",
+      "copyAll": "Copy all",
+      "copied": "Copied!",
+      "apply": "Apply to canvas"
+    },
+    "cost": {
+      "title": "Estimated input cost",
+      "note": "Input cost only. Prices may vary."
+    },
+    "memory": {
+      "title": "Context Memory",
+      "new": "New",
+      "searchPlaceholder": "Search memory…",
+      "noBlocks": "No memory blocks yet. Click + New to add one.",
+      "noResults": "No results.",
+      "namePlaceholder": "Name",
+      "contentPlaceholder": "Content…",
+      "tagsPlaceholder": "Tags (comma separated)",
+      "save": "Save",
+      "cancel": "Cancel"
+    },
+    "versioning": {
+      "title": "Version History",
+      "messagePlaceholder": "Version message (optional)",
+      "save": "Save",
+      "saving": "Saving…",
+      "compareHint": "Select second version to compare",
+      "noVersions": "No saved versions yet.",
+      "restore": "Restore",
+      "compare": "Compare",
+      "diff": "Diff",
+      "justNow": "just now",
+      "minsAgo": "{n}m ago",
+      "hoursAgo": "{n}h ago",
+      "daysAgo": "{n}d ago"
+    },
+    "outputButtons": {
+      "debug": "Debug",
+      "compress": "Compress",
+      "score": "Score"
+    },
+    "inputButtons": {
+      "systemPrompt": "System Prompt"
+    }
+  },
   "blocks": {
     "document": {
       "label": "Document",

--- a/app/src/i18n/fr.json
+++ b/app/src/i18n/fr.json
@@ -231,6 +231,89 @@
     "export": "Exporter les projets",
     "import": "Importer des projets"
   },
+  "ide": {
+    "close": "Fermer",
+    "debugger": {
+      "title": "Débogueur de prompt",
+      "loading": "Analyse en cours…",
+      "empty": "Cliquez sur « Déboguer » dans le panneau Résultat pour analyser votre prompt.",
+      "noIssues": "Aucun problème détecté — excellent prompt !",
+      "scoreLabel": "/ 100",
+      "wordsBefore": "Avant : {n} mots",
+      "wordsSaved": "La correction économise ~{n} mots",
+      "suggestions": "Suggestions",
+      "applyFix": "Appliquer le prompt corrigé"
+    },
+    "compressor": {
+      "title": "Compresseur de prompt",
+      "loading": "Compression…",
+      "targetReduction": "Réduction cible :",
+      "before": "Avant",
+      "after": "Après",
+      "saved": "Économisé",
+      "words": "mots",
+      "original": "Original",
+      "compressed": "Prompt compressé",
+      "changes": "Modifications",
+      "noChanges": "(aucune modification)",
+      "apply": "Appliquer le prompt compressé"
+    },
+    "critic": {
+      "title": "Critique IA de prompt",
+      "loading": "Évaluation en cours…",
+      "empty": "Cliquez sur « Score » dans le panneau Résultat pour évaluer votre prompt.",
+      "overallScore": "Score global",
+      "strengths": "Points forts",
+      "weaknesses": "Points faibles"
+    },
+    "systemPrompt": {
+      "title": "Générateur de system prompt",
+      "loading": "Génération en cours…",
+      "empty": "Cliquez sur « System Prompt » dans la saisie pour démarrer.",
+      "copyAll": "Tout copier",
+      "copied": "Copié !",
+      "apply": "Appliquer au canvas"
+    },
+    "cost": {
+      "title": "Coût d'entrée estimé",
+      "note": "Coût d'entrée uniquement. Prix susceptibles de varier."
+    },
+    "memory": {
+      "title": "Mémoire contextuelle",
+      "new": "Nouveau",
+      "searchPlaceholder": "Rechercher…",
+      "noBlocks": "Aucun bloc en mémoire. Cliquez sur + Nouveau pour en ajouter.",
+      "noResults": "Aucun résultat.",
+      "namePlaceholder": "Nom",
+      "contentPlaceholder": "Contenu…",
+      "tagsPlaceholder": "Tags (séparés par des virgules)",
+      "save": "Sauvegarder",
+      "cancel": "Annuler"
+    },
+    "versioning": {
+      "title": "Historique des versions",
+      "messagePlaceholder": "Message de version (optionnel)",
+      "save": "Sauvegarder",
+      "saving": "Sauvegarde…",
+      "compareHint": "Sélectionnez une seconde version pour comparer",
+      "noVersions": "Aucune version sauvegardée.",
+      "restore": "Restaurer",
+      "compare": "Comparer",
+      "diff": "Diff",
+      "justNow": "à l'instant",
+      "minsAgo": "il y a {n}min",
+      "hoursAgo": "il y a {n}h",
+      "daysAgo": "il y a {n}j"
+    },
+    "outputButtons": {
+      "debug": "Déboguer",
+      "compress": "Compresser",
+      "score": "Score"
+    },
+    "inputButtons": {
+      "systemPrompt": "System Prompt"
+    }
+  },
   "blocks": {
     "document": {
       "label": "Document",

--- a/app/src/i18n/fr.json
+++ b/app/src/i18n/fr.json
@@ -264,7 +264,15 @@
       "empty": "Cliquez sur « Score » dans le panneau Résultat pour évaluer votre prompt.",
       "overallScore": "Score global",
       "strengths": "Points forts",
-      "weaknesses": "Points faibles"
+      "weaknesses": "Points faibles",
+      "dimensions": {
+        "clarity": "Clarté",
+        "specificity": "Spécificité",
+        "structure": "Structure",
+        "examples": "Exemples",
+        "constraints": "Contraintes",
+        "format": "Format"
+      }
     },
     "systemPrompt": {
       "title": "Générateur de system prompt",

--- a/app/src/i18n/translations.ts
+++ b/app/src/i18n/translations.ts
@@ -191,6 +191,18 @@ export interface Translations {
     docs: string
     openPanel: string
   }
+  ide: {
+    close: string
+    debugger: { title: string; loading: string; empty: string; noIssues: string; scoreLabel: string; wordsBefore: string; wordsSaved: string; suggestions: string; applyFix: string }
+    compressor: { title: string; loading: string; targetReduction: string; before: string; after: string; saved: string; words: string; original: string; compressed: string; changes: string; noChanges: string; apply: string }
+    critic: { title: string; loading: string; empty: string; overallScore: string; strengths: string; weaknesses: string }
+    systemPrompt: { title: string; loading: string; empty: string; copyAll: string; copied: string; apply: string }
+    cost: { title: string; note: string }
+    memory: { title: string; new: string; searchPlaceholder: string; noBlocks: string; noResults: string; namePlaceholder: string; contentPlaceholder: string; tagsPlaceholder: string; save: string; cancel: string }
+    versioning: { title: string; messagePlaceholder: string; save: string; saving: string; compareHint: string; noVersions: string; restore: string; compare: string; diff: string; justNow: string; minsAgo: string; hoursAgo: string; daysAgo: string }
+    outputButtons: { debug: string; compress: string; score: string }
+    inputButtons: { systemPrompt: string }
+  }
   blocks: Record<BlockType, BlockTranslation>
 }
 
@@ -225,6 +237,7 @@ function build(raw: RawLocale): Translations {
     starPopup: raw.starPopup,
     projects: raw.projects,
     makeIntegration: raw.makeIntegration,
+    ide: (raw as any).ide,
     blocks: raw.blocks as Record<BlockType, BlockTranslation>,
   }
 }

--- a/app/src/i18n/translations.ts
+++ b/app/src/i18n/translations.ts
@@ -195,7 +195,7 @@ export interface Translations {
     close: string
     debugger: { title: string; loading: string; empty: string; noIssues: string; scoreLabel: string; wordsBefore: string; wordsSaved: string; suggestions: string; applyFix: string }
     compressor: { title: string; loading: string; targetReduction: string; before: string; after: string; saved: string; words: string; original: string; compressed: string; changes: string; noChanges: string; apply: string }
-    critic: { title: string; loading: string; empty: string; overallScore: string; strengths: string; weaknesses: string }
+    critic: { title: string; loading: string; empty: string; overallScore: string; strengths: string; weaknesses: string; dimensions: Record<string, string> }
     systemPrompt: { title: string; loading: string; empty: string; copyAll: string; copied: string; apply: string }
     cost: { title: string; note: string }
     memory: { title: string; new: string; searchPlaceholder: string; noBlocks: string; noResults: string; namePlaceholder: string; contentPlaceholder: string; tagsPlaceholder: string; save: string; cancel: string }

--- a/app/src/lib/db.ts
+++ b/app/src/lib/db.ts
@@ -1,0 +1,69 @@
+import { openDB, type DBSchema, type IDBPDatabase } from 'idb'
+import type { FlomptNode, FlomptEdge } from '@/types/blocks'
+
+export interface MemoryBlock {
+  id: string
+  name: string
+  category: 'company' | 'persona' | 'style' | 'tone' | 'domain' | 'custom'
+  blockType: string
+  content: string
+  tags: string[]
+  usageCount: number
+  lastUsedAt: string | null
+  createdAt: string
+  isFavorite: boolean
+}
+
+export interface PromptVersion {
+  id: string
+  projectId: string
+  version: number
+  label: string
+  message: string
+  prompt: string
+  nodes: FlomptNode[]
+  edges: FlomptEdge[]
+  tokenCount: number
+  createdAt: string
+  tags: string[]
+}
+
+export interface UserTemplate {
+  id: string
+  source: 'user'
+  category: string
+  name: string
+  description: string
+  blocks: Array<{ type: string; content: string }>
+  createdAt: string
+  updatedAt: string
+  starred: boolean
+  usageCount: number
+}
+
+interface FlomptDB extends DBSchema {
+  memory_blocks: { key: string; value: MemoryBlock }
+  versions: { key: string; value: PromptVersion; indexes: { 'by-project': string } }
+  user_templates: { key: string; value: UserTemplate }
+}
+
+let _db: IDBPDatabase<FlomptDB> | null = null
+
+export async function getDB(): Promise<IDBPDatabase<FlomptDB>> {
+  if (_db) return _db
+  _db = await openDB<FlomptDB>('flompt-ide', 1, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains('memory_blocks')) {
+        db.createObjectStore('memory_blocks', { keyPath: 'id' })
+      }
+      if (!db.objectStoreNames.contains('versions')) {
+        const vs = db.createObjectStore('versions', { keyPath: 'id' })
+        vs.createIndex('by-project', 'projectId')
+      }
+      if (!db.objectStoreNames.contains('user_templates')) {
+        db.createObjectStore('user_templates', { keyPath: 'id' })
+      }
+    },
+  })
+  return _db
+}

--- a/app/src/lib/diff.ts
+++ b/app/src/lib/diff.ts
@@ -1,0 +1,44 @@
+export interface DiffLine {
+  type: 'added' | 'removed' | 'unchanged'
+  content: string
+  lineNumberBefore?: number
+  lineNumberAfter?: number
+}
+
+export function computeLineDiff(textA: string, textB: string): DiffLine[] {
+  const linesA = textA.split('\n')
+  const linesB = textB.split('\n')
+  const m = linesA.length, n = linesB.length
+
+  // LCS-based diff (simple implementation)
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0))
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      if (linesA[i] === linesB[j]) {
+        dp[i][j] = dp[i + 1][j + 1] + 1
+      } else {
+        dp[i][j] = Math.max(dp[i + 1][j], dp[i][j + 1])
+      }
+    }
+  }
+
+  const result: DiffLine[] = []
+  let i = 0, j = 0, lineA = 1, lineB = 1
+
+  while (i < m && j < n) {
+    if (linesA[i] === linesB[j]) {
+      result.push({ type: 'unchanged', content: linesA[i], lineNumberBefore: lineA++, lineNumberAfter: lineB++ })
+      i++; j++
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      result.push({ type: 'removed', content: linesA[i], lineNumberBefore: lineA++ })
+      i++
+    } else {
+      result.push({ type: 'added', content: linesB[j], lineNumberAfter: lineB++ })
+      j++
+    }
+  }
+  while (i < m) { result.push({ type: 'removed', content: linesA[i++], lineNumberBefore: lineA++ }) }
+  while (j < n) { result.push({ type: 'added', content: linesB[j++], lineNumberAfter: lineB++ }) }
+
+  return result
+}

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -129,3 +129,51 @@ export function watchJobStatus(
 }
 
 // compilePrompt removed — assembly is now 100% local (see PromptOutput.tsx)
+
+// ─── AI IDE features ─────────────────────────────────────────────────────────
+
+export interface DebugResult {
+  issues: Array<{
+    id: string; severity: string; category: string
+    message: string; location?: string; suggestion: string
+  }>
+  score: number; fixedPrompt: string; improvements: string[]
+  tokensBefore: number; tokensAfter: number
+}
+
+export const debugPrompt = async (prompt: string): Promise<DebugResult> => {
+  const { data } = await client.post<DebugResult>('/debug', { prompt })
+  return data
+}
+
+export interface CompressResult {
+  compressedPrompt: string
+  changes: Array<{ type: string; original: string; replacement: string | null; reason: string; tokensSaved: number }>
+  tokensBefore: number; tokensAfter: number; reductionPercent: number
+}
+
+export const compressPrompt = async (prompt: string, targetReduction = 0.5): Promise<CompressResult> => {
+  const { data } = await client.post<CompressResult>('/compress', { prompt, target_reduction: targetReduction })
+  return data
+}
+
+export interface CriticResult {
+  overallScore: number; grade: string
+  dimensions: Array<{ name: string; score: number; feedback: string }>
+  strengths: string[]; weaknesses: string[]; topRecommendation: string
+}
+
+export const critiquePrompt = async (prompt: string): Promise<CriticResult> => {
+  const { data } = await client.post<CriticResult>('/critic', { prompt })
+  return data
+}
+
+export interface SystemPromptResult {
+  sections: Array<{ name: string; content: string }>
+  fullPrompt: string; totalTokens: number
+}
+
+export const generateSystemPrompt = async (prompt: string): Promise<SystemPromptResult> => {
+  const { data } = await client.post<SystemPromptResult>('/system-prompt', { prompt })
+  return data
+}

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -182,8 +182,8 @@ export interface CriticResult {
   strengths: string[]; weaknesses: string[]; topRecommendation: string
 }
 
-export const critiquePrompt = async (prompt: string): Promise<CriticResult> => {
-  const { data } = await client.post<any>('/critic', { prompt })
+export const critiquePrompt = async (prompt: string, locale = 'en'): Promise<CriticResult> => {
+  const { data } = await client.post<any>('/critic', { prompt, locale })
   return {
     overallScore: data.overall_score ?? 5,
     grade: data.grade ?? 'C',

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -142,8 +142,15 @@ export interface DebugResult {
 }
 
 export const debugPrompt = async (prompt: string): Promise<DebugResult> => {
-  const { data } = await client.post<DebugResult>('/debug', { prompt })
-  return data
+  const { data } = await client.post<any>('/debug', { prompt })
+  return {
+    issues: data.issues ?? [],
+    score: data.score ?? 50,
+    fixedPrompt: data.fixed_prompt ?? prompt,
+    improvements: data.improvements ?? [],
+    tokensBefore: data.tokens_before ?? 0,
+    tokensAfter: data.tokens_after ?? 0,
+  }
 }
 
 export interface CompressResult {
@@ -153,8 +160,20 @@ export interface CompressResult {
 }
 
 export const compressPrompt = async (prompt: string, targetReduction = 0.5): Promise<CompressResult> => {
-  const { data } = await client.post<CompressResult>('/compress', { prompt, target_reduction: targetReduction })
-  return data
+  const { data } = await client.post<any>('/compress', { prompt, target_reduction: targetReduction })
+  return {
+    compressedPrompt: data.compressed_prompt ?? prompt,
+    changes: (data.changes ?? []).map((c: any) => ({
+      type: c.type,
+      original: c.original,
+      replacement: c.replacement ?? null,
+      reason: c.reason,
+      tokensSaved: c.tokens_saved ?? 0,
+    })),
+    tokensBefore: data.tokens_before ?? 0,
+    tokensAfter: data.tokens_after ?? 0,
+    reductionPercent: data.reduction_percent ?? 0,
+  }
 }
 
 export interface CriticResult {
@@ -164,8 +183,15 @@ export interface CriticResult {
 }
 
 export const critiquePrompt = async (prompt: string): Promise<CriticResult> => {
-  const { data } = await client.post<CriticResult>('/critic', { prompt })
-  return data
+  const { data } = await client.post<any>('/critic', { prompt })
+  return {
+    overallScore: data.overall_score ?? 5,
+    grade: data.grade ?? 'C',
+    dimensions: data.dimensions ?? [],
+    strengths: data.strengths ?? [],
+    weaknesses: data.weaknesses ?? [],
+    topRecommendation: data.top_recommendation ?? '',
+  }
 }
 
 export interface SystemPromptResult {
@@ -174,6 +200,10 @@ export interface SystemPromptResult {
 }
 
 export const generateSystemPrompt = async (prompt: string): Promise<SystemPromptResult> => {
-  const { data } = await client.post<SystemPromptResult>('/system-prompt', { prompt })
-  return data
+  const { data } = await client.post<any>('/system-prompt', { prompt })
+  return {
+    sections: data.sections ?? [],
+    fullPrompt: data.full_prompt ?? '',
+    totalTokens: data.total_tokens ?? 0,
+  }
 }

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -141,8 +141,8 @@ export interface DebugResult {
   tokensBefore: number; tokensAfter: number
 }
 
-export const debugPrompt = async (prompt: string): Promise<DebugResult> => {
-  const { data } = await client.post<any>('/debug', { prompt })
+export const debugPrompt = async (prompt: string, locale = 'en'): Promise<DebugResult> => {
+  const { data } = await client.post<any>('/debug', { prompt, locale })
   return {
     issues: data.issues ?? [],
     score: data.score ?? 50,
@@ -159,8 +159,8 @@ export interface CompressResult {
   tokensBefore: number; tokensAfter: number; reductionPercent: number
 }
 
-export const compressPrompt = async (prompt: string, targetReduction = 0.5): Promise<CompressResult> => {
-  const { data } = await client.post<any>('/compress', { prompt, target_reduction: targetReduction })
+export const compressPrompt = async (prompt: string, targetReduction = 0.5, locale = 'en'): Promise<CompressResult> => {
+  const { data } = await client.post<any>('/compress', { prompt, target_reduction: targetReduction, locale })
   return {
     compressedPrompt: data.compressed_prompt ?? prompt,
     changes: (data.changes ?? []).map((c: any) => ({
@@ -199,8 +199,8 @@ export interface SystemPromptResult {
   fullPrompt: string; totalTokens: number
 }
 
-export const generateSystemPrompt = async (prompt: string): Promise<SystemPromptResult> => {
-  const { data } = await client.post<any>('/system-prompt', { prompt })
+export const generateSystemPrompt = async (prompt: string, locale = 'en'): Promise<SystemPromptResult> => {
+  const { data } = await client.post<any>('/system-prompt', { prompt, locale })
   return {
     sections: data.sections ?? [],
     fullPrompt: data.full_prompt ?? '',

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -3166,7 +3166,7 @@ body {
 .token-badge--clickable:hover { text-decoration: underline; }
 .cost-popover-backdrop { position: fixed; inset: 0; z-index: 10; }
 .cost-popover {
-  position: absolute; top: calc(100% + 6px); left: 50%; transform: translateX(-50%);
+  position: absolute; top: calc(100% + 6px); right: 0;
   z-index: 11; background: var(--bg-2); border: 1px solid var(--border-strong);
   border-radius: 10px; padding: 12px; min-width: 220px; box-shadow: 0 8px 24px rgba(0,0,0,0.3);
 }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -2590,7 +2590,7 @@ body {
 .make-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 98;
+  z-index: 101;
   background: rgba(0, 0, 0, 0.45);
   animation: makeBackdropIn var(--transition-base) ease forwards;
 }
@@ -2606,7 +2606,7 @@ body {
   top: 0;
   right: 0;
   bottom: 0;
-  z-index: 99;
+  z-index: 102;
   width: 300px;
   background: var(--bg-2);
   border-left: 1px solid var(--border-strong);

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -3032,3 +3032,210 @@ body {
 @media (max-width: 380px) {
   .make-panel { width: 100%; }
 }
+
+/* ─── Debugger Panel ──────────────────────────────────────────────────── */
+.debugger-backdrop {
+  position: fixed; inset: 0; z-index: 101;
+  background: rgba(0,0,0,0.4);
+  animation: makeBackdropIn var(--transition-base) ease forwards;
+}
+.debugger-panel {
+  position: fixed; top: 0; left: 0; bottom: 0;
+  z-index: 102; width: 340px;
+  background: var(--bg-2); border-right: 1px solid var(--border-strong);
+  display: flex; flex-direction: column; overflow: hidden;
+}
+.debugger-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 14px; border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.debugger-brand { display: flex; align-items: center; gap: 8px; }
+.debugger-title { font-size: 13px; font-weight: 600; color: var(--text); }
+.debugger-body { flex: 1; overflow-y: auto; padding: 14px; display: flex; flex-direction: column; gap: 12px; }
+.debugger-loading { display: flex; align-items: center; gap: 10px; color: var(--text-dim); padding: 24px; }
+.debugger-error { color: var(--error, #ef4444); font-size: 12px; padding: 10px; background: rgba(239,68,68,0.08); border-radius: 6px; }
+.debugger-empty { color: var(--text-dim); font-size: 12px; text-align: center; padding: 24px 12px; }
+.debugger-score-row { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+.debugger-score-gauge { display: flex; align-items: baseline; gap: 4px; }
+.debugger-score-number { font-size: 36px; font-weight: 700; line-height: 1; }
+.debugger-score-label { font-size: 13px; color: var(--text-dim); }
+.debugger-token-delta { display: flex; flex-direction: column; gap: 2px; font-size: 11px; color: var(--text-dim); }
+.debugger-token-saved { color: #22c55e; }
+.debugger-no-issues { display: flex; align-items: center; gap: 8px; font-size: 13px; color: #22c55e; }
+.debugger-issues { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.debugger-issue { padding: 10px 12px; border-radius: 8px; border: 1px solid var(--border); }
+.debugger-issue--error   { border-color: rgba(239,68,68,0.3); background: rgba(239,68,68,0.04); }
+.debugger-issue--warning { border-color: rgba(245,158,11,0.3); background: rgba(245,158,11,0.04); }
+.debugger-issue--info    { border-color: rgba(96,165,250,0.3); background: rgba(96,165,250,0.04); }
+.debugger-issue-header { display: flex; align-items: flex-start; gap: 7px; margin-bottom: 4px; }
+.debugger-issue-message { font-size: 12px; font-weight: 500; color: var(--text); }
+.debugger-issue-suggestion { font-size: 11px; color: var(--text-dim); margin: 0; padding-left: 20px; }
+.debugger-section-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-dim); font-weight: 600; }
+.debugger-improvements { display: flex; flex-direction: column; gap: 6px; }
+.debugger-improvements ul { margin: 4px 0 0; padding-left: 16px; font-size: 12px; color: var(--text-dim); display: flex; flex-direction: column; gap: 3px; }
+.debugger-apply-btn {
+  display: flex; align-items: center; gap: 6px; justify-content: center;
+  padding: 8px 14px; border-radius: 8px; border: none; cursor: pointer;
+  background: var(--accent, #FF3570); color: white; font-size: 12px; font-weight: 500;
+  transition: opacity 0.15s;
+}
+.debugger-apply-btn:hover { opacity: 0.85; }
+
+/* ─── Critic Panel ──────────────────────────────────────────────────── */
+.critic-panel {
+  position: fixed; top: 0; left: 0; bottom: 0;
+  z-index: 102; width: 380px;
+  background: var(--bg-2); border-right: 1px solid var(--border-strong);
+  display: flex; flex-direction: column; overflow: hidden;
+}
+.critic-score-row { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+.critic-grade { font-size: 48px; font-weight: 800; line-height: 1; }
+.critic-overall-score { font-size: 22px; font-weight: 700; }
+.critic-recommendation {
+  display: flex; align-items: flex-start; gap: 8px;
+  padding: 10px 12px; border-radius: 8px;
+  background: rgba(245,158,11,0.08); border: 1px solid rgba(245,158,11,0.2);
+  font-size: 12px; color: var(--text);
+}
+.critic-feedback-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.critic-dim { padding: 8px 10px; background: var(--surface, #2a2a2e); border-radius: 8px; }
+.critic-dim-header { display: flex; justify-content: space-between; margin-bottom: 4px; }
+.critic-dim-name { font-size: 11px; font-weight: 600; color: var(--text); text-transform: capitalize; }
+.critic-dim-score { font-size: 11px; font-weight: 700; }
+.critic-dim-feedback { font-size: 10px; color: var(--text-dim); margin: 0; line-height: 1.4; }
+.critic-section { display: flex; flex-direction: column; gap: 4px; }
+.critic-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.critic-list li { font-size: 12px; color: var(--text-dim); padding-left: 12px; position: relative; }
+.critic-list--strengths li::before { content: '✓'; position: absolute; left: 0; color: #22c55e; }
+.critic-list--weaknesses li::before { content: '✗'; position: absolute; left: 0; color: #ef4444; }
+.radar-chart { display: block; }
+
+/* ─── Compressor Modal ──────────────────────────────────────────────────── */
+.compressor-overlay { position: fixed; inset: 0; z-index: 200; display: flex; align-items: center; justify-content: center; }
+.compressor-backdrop { position: absolute; inset: 0; background: rgba(0,0,0,0.6); }
+.compressor-modal {
+  position: relative; z-index: 1; width: min(90vw, 860px);
+  max-height: 90vh; background: var(--bg-2);
+  border: 1px solid var(--border-strong); border-radius: 14px;
+  display: flex; flex-direction: column; overflow: hidden;
+}
+.compressor-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 16px; border-bottom: 1px solid var(--border); flex-shrink: 0;
+}
+.compressor-title { font-size: 14px; font-weight: 600; }
+.compressor-target-row { display: flex; align-items: center; gap: 6px; }
+.compressor-body { flex: 1; overflow-y: auto; display: flex; flex-direction: column; }
+.compressor-stats { display: flex; gap: 24px; padding: 14px 16px; border-bottom: 1px solid var(--border); }
+.compressor-stat { display: flex; flex-direction: column; gap: 2px; }
+.compressor-stat-label { font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-dim); }
+.compressor-stat-value { font-size: 18px; font-weight: 700; }
+.compressor-columns { display: grid; grid-template-columns: 1fr 1fr; gap: 0; flex: 1; }
+.compressor-col { padding: 14px 16px; display: flex; flex-direction: column; gap: 6px; }
+.compressor-col:first-child { border-right: 1px solid var(--border); }
+.compressor-pre { margin: 0; font-size: 11px; line-height: 1.6; color: var(--text-dim); white-space: pre-wrap; word-break: break-word; font-family: monospace; background: var(--surface, #2a2a2e); padding: 10px; border-radius: 6px; flex: 1; }
+.compressor-changes { padding: 12px 16px; border-top: 1px solid var(--border); display: flex; flex-direction: column; gap: 8px; }
+.compressor-change-list { list-style: none; margin: 6px 0 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.compressor-change-item { display: flex; align-items: center; gap: 6px; font-size: 11px; }
+.compressor-change-type { font-weight: 600; text-transform: capitalize; color: var(--text-dim); min-width: 60px; }
+.compressor-change-reason { flex: 1; color: var(--text-dim); }
+.compressor-change-saved { color: #22c55e; font-weight: 600; }
+
+/* ─── System Prompt Modal ──────────────────────────────────────────────── */
+.sysprompt-sections { flex: 1; overflow-y: auto; padding: 12px 16px; display: flex; flex-direction: column; gap: 10px; }
+.sysprompt-section { display: flex; flex-direction: column; gap: 6px; }
+.sysprompt-section-label {
+  font-size: 11px; font-weight: 700; letter-spacing: 0.08em;
+  color: var(--section-color, var(--text-dim));
+  text-transform: uppercase;
+  border-left: 3px solid var(--section-color, var(--border));
+  padding-left: 8px;
+}
+.sysprompt-textarea {
+  width: 100%; padding: 8px 10px; border-radius: 6px;
+  background: var(--surface, #2a2a2e); border: 1px solid var(--border);
+  color: var(--text); font-size: 12px; line-height: 1.5;
+  resize: vertical; font-family: inherit; box-sizing: border-box;
+}
+.sysprompt-textarea:focus { border-color: var(--accent); outline: none; }
+
+/* ─── Cost Popover ──────────────────────────────────────────────────── */
+.cost-popover-wrapper { position: relative; display: inline-block; }
+.token-badge--clickable { cursor: pointer; background: transparent; border: none; font-size: 11px; padding: 0; }
+.token-badge--clickable:hover { text-decoration: underline; }
+.cost-popover-backdrop { position: fixed; inset: 0; z-index: 10; }
+.cost-popover {
+  position: absolute; top: calc(100% + 6px); left: 50%; transform: translateX(-50%);
+  z-index: 11; background: var(--bg-2); border: 1px solid var(--border-strong);
+  border-radius: 10px; padding: 12px; min-width: 220px; box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+}
+.cost-popover-title { font-size: 11px; font-weight: 600; color: var(--text-dim); margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.06em; }
+.cost-table { width: 100%; border-collapse: collapse; }
+.cost-table td { padding: 3px 0; font-size: 12px; }
+.cost-table-model { color: var(--text-dim); }
+.cost-table-price { text-align: right; color: var(--text); font-weight: 600; font-family: monospace; }
+.cost-popover-note { font-size: 10px; color: var(--text-dim); margin: 8px 0 0; }
+
+/* ─── Context Memory Panel ──────────────────────────────────────────────── */
+.memory-panel {
+  position: fixed; top: 0; left: 0; bottom: 0;
+  z-index: 102; width: 320px;
+  background: var(--bg-2); border-right: 1px solid var(--border-strong);
+  display: flex; flex-direction: column; overflow: hidden;
+}
+.memory-create-form { padding: 12px 14px; border-bottom: 1px solid var(--border); display: flex; flex-direction: column; gap: 8px; }
+.memory-search { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--border); }
+.memory-search-icon { color: var(--text-dim); flex-shrink: 0; }
+.memory-search-input { flex: 1; background: transparent; border: none; color: var(--text); font-size: 12px; outline: none; }
+.memory-list { flex: 1; overflow-y: auto; padding: 10px 10px; display: flex; flex-direction: column; gap: 8px; }
+.memory-item { padding: 10px 12px; background: var(--surface, #2a2a2e); border-radius: 8px; border: 1px solid var(--border); }
+.memory-item-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 6px; margin-bottom: 6px; }
+.memory-item-name { font-size: 12px; font-weight: 600; color: var(--text); }
+.memory-item-category { display: inline-block; font-size: 10px; padding: 1px 6px; border-radius: 20px; background: var(--border); color: var(--text-dim); margin-left: 6px; }
+.memory-item-actions { display: flex; gap: 2px; flex-shrink: 0; }
+.memory-item-preview { font-size: 11px; color: var(--text-dim); margin: 0 0 6px; line-height: 1.4; }
+.memory-item-tags { display: flex; flex-wrap: wrap; gap: 4px; }
+.memory-item-tag { font-size: 10px; padding: 1px 6px; border-radius: 20px; background: rgba(255,53,112,0.1); color: var(--accent, #FF3570); }
+
+/* ─── Version History Panel ──────────────────────────────────────────────── */
+.version-panel {
+  position: fixed; top: 0; right: 0; bottom: 0;
+  z-index: 102; width: 340px;
+  background: var(--bg-2); border-left: 1px solid var(--border-strong);
+  display: flex; flex-direction: column; overflow: hidden;
+}
+.version-save-row { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--border); }
+.version-compare-hint { padding: 6px 14px; font-size: 11px; color: #60a5fa; background: rgba(96,165,250,0.08); border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 6px; }
+.version-list { flex: 1; overflow-y: auto; padding: 10px; display: flex; flex-direction: column; gap: 6px; }
+.version-item { padding: 10px 12px; background: var(--surface, #2a2a2e); border-radius: 8px; border: 1px solid var(--border); }
+.version-item--selected { border-color: #60a5fa; background: rgba(96,165,250,0.06); }
+.version-item-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; }
+.version-item-label { font-size: 12px; font-weight: 600; color: var(--text); }
+.version-item-time { font-size: 10px; color: var(--text-dim); display: flex; align-items: center; gap: 3px; }
+.version-item-tokens { font-size: 10px; color: var(--text-dim); margin-bottom: 6px; display: block; }
+.version-item-actions { display: flex; gap: 4px; flex-wrap: wrap; }
+
+/* ─── Version Diff ──────────────────────────────────────────────────── */
+.version-diff { border-bottom: 1px solid var(--border); }
+.version-diff-header { display: flex; align-items: center; justify-content: space-between; padding: 6px 14px; }
+.version-diff-body { max-height: 200px; overflow-y: auto; font-family: monospace; font-size: 11px; }
+.diff-line { display: flex; min-height: 18px; }
+.diff-line--added   { background: rgba(34,197,94,0.1); }
+.diff-line--removed { background: rgba(239,68,68,0.1); }
+.diff-line-num { width: 28px; min-width: 28px; padding: 1px 4px; text-align: right; color: var(--text-dim); font-size: 10px; border-right: 1px solid var(--border); opacity: 0.6; }
+.diff-line-marker { width: 16px; min-width: 16px; text-align: center; font-weight: bold; }
+.diff-line--added   .diff-line-marker { color: #22c55e; }
+.diff-line--removed .diff-line-marker { color: #ef4444; }
+.diff-line-content { flex: 1; padding: 1px 6px; white-space: pre-wrap; word-break: break-all; color: var(--text); }
+
+/* ─── IDE action buttons in output ──────────────────────────────────────── */
+.output-ide-actions { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 4px; }
+
+/* Mobile adjustments */
+@media (max-width: 640px) {
+  .debugger-panel, .critic-panel, .memory-panel { width: 100%; }
+  .version-panel { width: 100%; }
+  .compressor-columns { grid-template-columns: 1fr; }
+  .critic-feedback-grid { grid-template-columns: 1fr; }
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -3229,6 +3229,26 @@ body {
 .diff-line--removed .diff-line-marker { color: #ef4444; }
 .diff-line-content { flex: 1; padding: 1px 6px; white-space: pre-wrap; word-break: break-all; color: var(--text); }
 
+/* ─── IDE shared close button ──────────────────────────────────────────── */
+.ide-close-btn {
+  display: flex; align-items: center; justify-content: center;
+  width: 30px; height: 30px; border-radius: 8px; border: none; cursor: pointer;
+  background: transparent; color: var(--text-dim);
+  transition: background 0.12s, color 0.12s; flex-shrink: 0;
+}
+.ide-close-btn:hover { background: rgba(255,255,255,0.07); color: var(--text); }
+
+/* ─── IDE shared action button (Restore, Compare…) ─────────────────────── */
+.ide-action-btn {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 4px 9px; border-radius: 7px;
+  border: 1px solid var(--border); background: transparent;
+  color: var(--text-dim); font-size: 11px; cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.ide-action-btn:hover { background: var(--surface-hover, rgba(255,255,255,0.05)); color: var(--text); border-color: var(--text-dim); }
+.ide-action-btn--danger:hover { border-color: #ef4444; color: #ef4444; background: rgba(239,68,68,0.07); }
+
 /* ─── IDE action buttons in output ──────────────────────────────────────── */
 .output-ide-actions { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 4px; }
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, Depends, HTTPException, Header
 from fastapi.middleware.cors import CORSMiddleware
 from app.routers import decompose, compile, stars
+from app.routers import debugger, compressor, critic, system_prompt
 from app.services.ai_service import llm_queue
 from app.services.job_store import job_store
 from app.auth import verify_job_token
@@ -41,6 +42,10 @@ app.add_middleware(
 app.include_router(decompose.router, prefix="/api", tags=["decompose"])
 app.include_router(compile.router, prefix="/api", tags=["compile"])
 app.include_router(stars.router, tags=["stars"])
+app.include_router(debugger.router, prefix="/api", tags=["debugger"])
+app.include_router(compressor.router, prefix="/api", tags=["compressor"])
+app.include_router(critic.router, prefix="/api", tags=["critic"])
+app.include_router(system_prompt.router, prefix="/api", tags=["system-prompt"])
 
 # ─── MCP Server (Streamable HTTP, stateless) ─────────────────────────────────
 app.mount("/mcp", _mcp_http_app)

--- a/backend/app/models/compressor.py
+++ b/backend/app/models/compressor.py
@@ -4,6 +4,7 @@ from typing import Literal
 class CompressRequest(BaseModel):
     prompt: str
     target_reduction: float = 0.5
+    locale: str = "en"
 
 class CompressChange(BaseModel):
     type: Literal["removed", "optimized", "merged"]

--- a/backend/app/models/compressor.py
+++ b/backend/app/models/compressor.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+from typing import Literal
+
+class CompressRequest(BaseModel):
+    prompt: str
+    target_reduction: float = 0.5
+
+class CompressChange(BaseModel):
+    type: Literal["removed", "optimized", "merged"]
+    original: str
+    replacement: str | None = None
+    reason: str
+    tokens_saved: int
+
+class CompressResult(BaseModel):
+    compressed_prompt: str
+    changes: list[CompressChange]
+    tokens_before: int
+    tokens_after: int
+    reduction_percent: float

--- a/backend/app/models/critic.py
+++ b/backend/app/models/critic.py
@@ -8,6 +8,7 @@ class CriticDimension(BaseModel):
 
 class CriticRequest(BaseModel):
     prompt: str
+    locale: str = "en"
 
 class CriticResult(BaseModel):
     overall_score: float

--- a/backend/app/models/critic.py
+++ b/backend/app/models/critic.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from typing import Literal
+
+class CriticDimension(BaseModel):
+    name: str
+    score: int
+    feedback: str
+
+class CriticRequest(BaseModel):
+    prompt: str
+
+class CriticResult(BaseModel):
+    overall_score: float
+    grade: Literal["A", "B", "C", "D", "F"]
+    dimensions: list[CriticDimension]
+    strengths: list[str]
+    weaknesses: list[str]
+    top_recommendation: str

--- a/backend/app/models/debugger.py
+++ b/backend/app/models/debugger.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+from typing import Literal
+
+class DebugRequest(BaseModel):
+    prompt: str
+
+class DebugIssue(BaseModel):
+    id: str
+    severity: Literal["error", "warning", "info"]
+    category: str
+    message: str
+    location: str | None = None
+    suggestion: str
+
+class DebugResult(BaseModel):
+    issues: list[DebugIssue]
+    score: int
+    fixed_prompt: str
+    improvements: list[str]
+    tokens_before: int
+    tokens_after: int

--- a/backend/app/models/debugger.py
+++ b/backend/app/models/debugger.py
@@ -3,6 +3,7 @@ from typing import Literal
 
 class DebugRequest(BaseModel):
     prompt: str
+    locale: str = "en"
 
 class DebugIssue(BaseModel):
     id: str

--- a/backend/app/models/system_prompt.py
+++ b/backend/app/models/system_prompt.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 
 class SystemPromptRequest(BaseModel):
     prompt: str
+    locale: str = "en"
 
 class SystemSection(BaseModel):
     name: str

--- a/backend/app/models/system_prompt.py
+++ b/backend/app/models/system_prompt.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+class SystemPromptRequest(BaseModel):
+    prompt: str
+
+class SystemSection(BaseModel):
+    name: str
+    content: str
+
+class SystemPromptResult(BaseModel):
+    sections: list[SystemSection]
+    full_prompt: str
+    total_tokens: int

--- a/backend/app/routers/compressor.py
+++ b/backend/app/routers/compressor.py
@@ -9,6 +9,6 @@ async def compress_endpoint(req: CompressRequest) -> CompressResult:
     if not req.prompt.strip():
         raise HTTPException(status_code=400, detail="Prompt cannot be empty")
     try:
-        return await compress_prompt(req.prompt, req.target_reduction)
+        return await compress_prompt(req.prompt, req.target_reduction, req.locale)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/routers/compressor.py
+++ b/backend/app/routers/compressor.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, HTTPException
+from app.models.compressor import CompressRequest, CompressResult
+from app.services.compressor_service import compress_prompt
+
+router = APIRouter()
+
+@router.post("/compress", response_model=CompressResult)
+async def compress_endpoint(req: CompressRequest) -> CompressResult:
+    if not req.prompt.strip():
+        raise HTTPException(status_code=400, detail="Prompt cannot be empty")
+    try:
+        return await compress_prompt(req.prompt, req.target_reduction)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/routers/critic.py
+++ b/backend/app/routers/critic.py
@@ -9,6 +9,6 @@ async def critic_endpoint(req: CriticRequest) -> CriticResult:
     if not req.prompt.strip():
         raise HTTPException(status_code=400, detail="Prompt cannot be empty")
     try:
-        return await critique_prompt(req.prompt)
+        return await critique_prompt(req.prompt, req.locale)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/routers/critic.py
+++ b/backend/app/routers/critic.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, HTTPException
+from app.models.critic import CriticRequest, CriticResult
+from app.services.critic_service import critique_prompt
+
+router = APIRouter()
+
+@router.post("/critic", response_model=CriticResult)
+async def critic_endpoint(req: CriticRequest) -> CriticResult:
+    if not req.prompt.strip():
+        raise HTTPException(status_code=400, detail="Prompt cannot be empty")
+    try:
+        return await critique_prompt(req.prompt)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/routers/debugger.py
+++ b/backend/app/routers/debugger.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, HTTPException
+from app.models.debugger import DebugRequest, DebugResult
+from app.services.debugger_service import debug_prompt
+
+router = APIRouter()
+
+@router.post("/debug", response_model=DebugResult)
+async def debug_endpoint(req: DebugRequest) -> DebugResult:
+    if not req.prompt.strip():
+        raise HTTPException(status_code=400, detail="Prompt cannot be empty")
+    try:
+        return await debug_prompt(req.prompt)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/routers/debugger.py
+++ b/backend/app/routers/debugger.py
@@ -9,6 +9,6 @@ async def debug_endpoint(req: DebugRequest) -> DebugResult:
     if not req.prompt.strip():
         raise HTTPException(status_code=400, detail="Prompt cannot be empty")
     try:
-        return await debug_prompt(req.prompt)
+        return await debug_prompt(req.prompt, req.locale)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/routers/system_prompt.py
+++ b/backend/app/routers/system_prompt.py
@@ -9,6 +9,6 @@ async def system_prompt_endpoint(req: SystemPromptRequest) -> SystemPromptResult
     if not req.prompt.strip():
         raise HTTPException(status_code=400, detail="Prompt cannot be empty")
     try:
-        return await generate_system_prompt(req.prompt)
+        return await generate_system_prompt(req.prompt, req.locale)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/routers/system_prompt.py
+++ b/backend/app/routers/system_prompt.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, HTTPException
+from app.models.system_prompt import SystemPromptRequest, SystemPromptResult
+from app.services.system_prompt_service import generate_system_prompt
+
+router = APIRouter()
+
+@router.post("/system-prompt", response_model=SystemPromptResult)
+async def system_prompt_endpoint(req: SystemPromptRequest) -> SystemPromptResult:
+    if not req.prompt.strip():
+        raise HTTPException(status_code=400, detail="Prompt cannot be empty")
+    try:
+        return await generate_system_prompt(req.prompt)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/services/compressor_service.py
+++ b/backend/app/services/compressor_service.py
@@ -22,9 +22,16 @@ Rules:
 - NEVER remove role, objective, constraints, or examples content
 - Respond in the same language as the prompt"""
 
-async def compress_prompt(prompt: str, target_reduction: float = 0.5) -> CompressResult:
+LOCALE_LANGUAGE_MAP: dict[str, str] = {
+    "en": "English", "fr": "French", "de": "German", "es": "Spanish",
+    "pt": "Portuguese", "ja": "Japanese", "tr": "Turkish",
+    "zh": "Chinese", "ar": "Arabic", "ru": "Russian",
+}
+
+async def compress_prompt(prompt: str, target_reduction: float = 0.5, locale: str = "en") -> CompressResult:
     tokens_before = len(prompt.split())
-    user_msg = f"Target: reduce by ~{int(target_reduction * 100)}%\n\nPrompt:\n{prompt}"
+    language = LOCALE_LANGUAGE_MAP.get(locale, "English")
+    user_msg = f"Respond entirely in {language}. Target: reduce by ~{int(target_reduction * 100)}%\n\nPrompt:\n{prompt}"
     raw = await _call_llm_direct(COMPRESS_SYSTEM_PROMPT, user_msg)
     data = json.loads(_strip_markdown_json(raw))
     compressed = data.get("compressed_prompt", prompt)

--- a/backend/app/services/compressor_service.py
+++ b/backend/app/services/compressor_service.py
@@ -1,0 +1,40 @@
+import json
+from app.services.ai_service import _call_llm_direct, _strip_markdown_json
+from app.models.compressor import CompressResult, CompressChange
+
+COMPRESS_SYSTEM_PROMPT = """You are a prompt compression expert. Reduce tokens while preserving intent. Return ONLY valid JSON:
+{
+  "compressed_prompt": "...",
+  "changes": [
+    {
+      "type": "removed|optimized|merged",
+      "original": "original text snippet",
+      "replacement": "shorter replacement or null if removed",
+      "reason": "why",
+      "tokens_saved": 5
+    }
+  ]
+}
+Rules:
+- Remove filler words (please, make sure to, I want you to, kindly)
+- Replace verbose phrases with concise equivalents
+- Merge duplicate/similar instructions
+- NEVER remove role, objective, constraints, or examples content
+- Respond in the same language as the prompt"""
+
+async def compress_prompt(prompt: str, target_reduction: float = 0.5) -> CompressResult:
+    tokens_before = len(prompt.split())
+    user_msg = f"Target: reduce by ~{int(target_reduction * 100)}%\n\nPrompt:\n{prompt}"
+    raw = await _call_llm_direct(COMPRESS_SYSTEM_PROMPT, user_msg)
+    data = json.loads(_strip_markdown_json(raw))
+    compressed = data.get("compressed_prompt", prompt)
+    tokens_after = len(compressed.split())
+    reduction = ((tokens_before - tokens_after) / max(tokens_before, 1)) * 100
+    changes = [CompressChange(**c) for c in data.get("changes", [])]
+    return CompressResult(
+        compressed_prompt=compressed,
+        changes=changes,
+        tokens_before=tokens_before,
+        tokens_after=tokens_after,
+        reduction_percent=round(reduction, 1),
+    )

--- a/backend/app/services/critic_service.py
+++ b/backend/app/services/critic_service.py
@@ -18,10 +18,18 @@ CRITIC_SYSTEM_PROMPT = """You are a senior prompt engineering evaluator. Score t
   "weaknesses": ["...", "..."],
   "top_recommendation": "Single most impactful improvement"
 }
-Grade: A=9-10, B=7-8, C=5-6, D=3-4, F=0-2. Respond in the prompt's language."""
+Grade: A=9-10, B=7-8, C=5-6, D=3-4, F=0-2."""
 
-async def critique_prompt(prompt: str) -> CriticResult:
-    raw = await _call_llm_direct(CRITIC_SYSTEM_PROMPT, prompt)
+LOCALE_LANGUAGE_MAP: dict[str, str] = {
+    "en": "English", "fr": "French", "de": "German", "es": "Spanish",
+    "pt": "Portuguese", "ja": "Japanese", "tr": "Turkish",
+    "zh": "Chinese", "ar": "Arabic", "ru": "Russian",
+}
+
+async def critique_prompt(prompt: str, locale: str = "en") -> CriticResult:
+    language = LOCALE_LANGUAGE_MAP.get(locale, "English")
+    user_msg = f"Respond entirely in {language}.\n\n{prompt}"
+    raw = await _call_llm_direct(CRITIC_SYSTEM_PROMPT, user_msg)
     data = json.loads(_strip_markdown_json(raw))
     dims = [CriticDimension(**d) for d in data.get("dimensions", [])]
     return CriticResult(

--- a/backend/app/services/critic_service.py
+++ b/backend/app/services/critic_service.py
@@ -1,0 +1,34 @@
+import json
+from app.services.ai_service import _call_llm_direct, _strip_markdown_json
+from app.models.critic import CriticResult, CriticDimension
+
+CRITIC_SYSTEM_PROMPT = """You are a senior prompt engineering evaluator. Score the prompt on 6 dimensions. Return ONLY valid JSON:
+{
+  "overall_score": 0-10,
+  "grade": "A|B|C|D|F",
+  "dimensions": [
+    { "name": "clarity",     "score": 0-10, "feedback": "..." },
+    { "name": "specificity", "score": 0-10, "feedback": "..." },
+    { "name": "structure",   "score": 0-10, "feedback": "..." },
+    { "name": "examples",    "score": 0-10, "feedback": "..." },
+    { "name": "constraints", "score": 0-10, "feedback": "..." },
+    { "name": "format",      "score": 0-10, "feedback": "..." }
+  ],
+  "strengths": ["...", "..."],
+  "weaknesses": ["...", "..."],
+  "top_recommendation": "Single most impactful improvement"
+}
+Grade: A=9-10, B=7-8, C=5-6, D=3-4, F=0-2. Respond in the prompt's language."""
+
+async def critique_prompt(prompt: str) -> CriticResult:
+    raw = await _call_llm_direct(CRITIC_SYSTEM_PROMPT, prompt)
+    data = json.loads(_strip_markdown_json(raw))
+    dims = [CriticDimension(**d) for d in data.get("dimensions", [])]
+    return CriticResult(
+        overall_score=float(data.get("overall_score", 5)),
+        grade=data.get("grade", "C"),
+        dimensions=dims,
+        strengths=data.get("strengths", []),
+        weaknesses=data.get("weaknesses", []),
+        top_recommendation=data.get("top_recommendation", ""),
+    )

--- a/backend/app/services/debugger_service.py
+++ b/backend/app/services/debugger_service.py
@@ -1,0 +1,39 @@
+import json
+import uuid
+from app.services.ai_service import _call_llm_direct, _strip_markdown_json
+from app.models.debugger import DebugResult, DebugIssue
+
+DEBUGGER_SYSTEM_PROMPT = """You are a prompt engineering expert. Analyze the prompt and return ONLY valid JSON (no markdown):
+{
+  "issues": [
+    {
+      "id": "unique-id",
+      "severity": "error|warning|info",
+      "category": "vague_objective|missing_role|missing_context|contradiction|redundancy|token_waste|missing_format",
+      "message": "Clear issue description in the prompt's language",
+      "location": "block_type or null",
+      "suggestion": "Specific actionable fix in the prompt's language"
+    }
+  ],
+  "score": 0-100,
+  "fixed_prompt": "Corrected version of the prompt",
+  "improvements": ["High-level suggestion 1"]
+}
+
+Scoring rules: start at 100. Deduct: missing_role -15, vague_objective -20, missing_context -10, contradiction -25, redundancy -10, token_waste -5, missing_format -10.
+Return at least score and fixed_prompt even if no issues found."""
+
+async def debug_prompt(prompt: str) -> DebugResult:
+    tokens_before = len(prompt.split())
+    raw = await _call_llm_direct(DEBUGGER_SYSTEM_PROMPT, prompt)
+    data = json.loads(_strip_markdown_json(raw))
+    issues = [DebugIssue(id=i.get("id", str(uuid.uuid4())), **{k: v for k, v in i.items() if k != "id"}) for i in data.get("issues", [])]
+    tokens_after = len(data.get("fixed_prompt", prompt).split())
+    return DebugResult(
+        issues=issues,
+        score=max(0, min(100, data.get("score", 50))),
+        fixed_prompt=data.get("fixed_prompt", prompt),
+        improvements=data.get("improvements", []),
+        tokens_before=tokens_before,
+        tokens_after=tokens_after,
+    )

--- a/backend/app/services/debugger_service.py
+++ b/backend/app/services/debugger_service.py
@@ -23,10 +23,19 @@ DEBUGGER_SYSTEM_PROMPT = """You are a prompt engineering expert. Analyze the pro
 Scoring rules: start at 100. Deduct: missing_role -15, vague_objective -20, missing_context -10, contradiction -25, redundancy -10, token_waste -5, missing_format -10.
 Return at least score and fixed_prompt even if no issues found."""
 
-async def debug_prompt(prompt: str) -> DebugResult:
+LOCALE_LANGUAGE_MAP: dict[str, str] = {
+    "en": "English", "fr": "French", "de": "German", "es": "Spanish",
+    "pt": "Portuguese", "ja": "Japanese", "tr": "Turkish",
+    "zh": "Chinese", "ar": "Arabic", "ru": "Russian",
+}
+
+async def debug_prompt(prompt: str, locale: str = "en") -> DebugResult:
     tokens_before = len(prompt.split())
-    raw = await _call_llm_direct(DEBUGGER_SYSTEM_PROMPT, prompt)
+    language = LOCALE_LANGUAGE_MAP.get(locale, "English")
+    user_msg = f"Respond entirely in {language}.\n\n{prompt}"
+    raw = await _call_llm_direct(DEBUGGER_SYSTEM_PROMPT, user_msg)
     data = json.loads(_strip_markdown_json(raw))
+
     issues = [DebugIssue(id=i.get("id", str(uuid.uuid4())), **{k: v for k, v in i.items() if k != "id"}) for i in data.get("issues", [])]
     tokens_after = len(data.get("fixed_prompt", prompt).split())
     return DebugResult(

--- a/backend/app/services/system_prompt_service.py
+++ b/backend/app/services/system_prompt_service.py
@@ -1,0 +1,35 @@
+import json
+from app.services.ai_service import _call_llm_direct, _strip_markdown_json
+from app.models.system_prompt import SystemPromptResult, SystemSection
+
+SYSTEM_PROMPT_GENERATOR = """Transform the given prompt into a structured system prompt with 6 sections. Return ONLY valid JSON:
+{
+  "sections": [
+    { "name": "SYSTEM",        "content": "..." },
+    { "name": "ROLE",          "content": "..." },
+    { "name": "CONTEXT",       "content": "..." },
+    { "name": "OBJECTIVE",     "content": "..." },
+    { "name": "CONSTRAINTS",   "content": "..." },
+    { "name": "OUTPUT_FORMAT", "content": "..." }
+  ]
+}
+Rules:
+- SYSTEM: overall behavior directive and capability framing
+- ROLE: persona, expertise level, communication style
+- CONTEXT: background info, domain knowledge, assumptions
+- OBJECTIVE: exact task — concrete and measurable
+- CONSTRAINTS: hard limits and what NOT to do
+- OUTPUT_FORMAT: structure, length, format expected
+- Be specific and actionable in each section
+- Respond in the same language as the input prompt"""
+
+async def generate_system_prompt(prompt: str) -> SystemPromptResult:
+    raw = await _call_llm_direct(SYSTEM_PROMPT_GENERATOR, prompt)
+    data = json.loads(_strip_markdown_json(raw))
+    sections = [SystemSection(**s) for s in data.get("sections", [])]
+    full = "\n\n".join(f"## {s.name}\n{s.content}" for s in sections)
+    return SystemPromptResult(
+        sections=sections,
+        full_prompt=full,
+        total_tokens=len(full.split()),
+    )

--- a/backend/app/services/system_prompt_service.py
+++ b/backend/app/services/system_prompt_service.py
@@ -20,11 +20,18 @@ Rules:
 - OBJECTIVE: exact task — concrete and measurable
 - CONSTRAINTS: hard limits and what NOT to do
 - OUTPUT_FORMAT: structure, length, format expected
-- Be specific and actionable in each section
-- Respond in the same language as the input prompt"""
+- Be specific and actionable in each section"""
 
-async def generate_system_prompt(prompt: str) -> SystemPromptResult:
-    raw = await _call_llm_direct(SYSTEM_PROMPT_GENERATOR, prompt)
+LOCALE_LANGUAGE_MAP: dict[str, str] = {
+    "en": "English", "fr": "French", "de": "German", "es": "Spanish",
+    "pt": "Portuguese", "ja": "Japanese", "tr": "Turkish",
+    "zh": "Chinese", "ar": "Arabic", "ru": "Russian",
+}
+
+async def generate_system_prompt(prompt: str, locale: str = "en") -> SystemPromptResult:
+    language = LOCALE_LANGUAGE_MAP.get(locale, "English")
+    user_msg = f"Respond entirely in {language}.\n\n{prompt}"
+    raw = await _call_llm_direct(SYSTEM_PROMPT_GENERATOR, user_msg)
     data = json.loads(_strip_markdown_json(raw))
     sections = [SystemSection(**s) for s in data.get("sections", [])]
     full = "\n\n".join(f"## {s.name}\n{s.content}" for s in sections)


### PR DESCRIPTION
## 7 new features + locale-aware AI responses

  Transforms flompt into a full **Prompt Engineering IDE** by adding 10 new features
  accessible directly from the output and input panels.

  ---

  ### Features added

  | Feature | Description |
  |---|---|
  | **Prompt Debugger** | Analyzes the prompt for issues (vague objective, missing role, contradictions…), scores it /100 and suggests a fixed version |
  | **Prompt Compressor** | Reduces token count while preserving intent, shows a detailed changelog of every change made |
  | **AI Prompt Critic** | Scores the prompt on 6 dimensions (clarity, specificity, structure, examples, constraints, format) with a radar chart |
  | **System Prompt Generator** | Transforms a raw prompt into a structured 6-section system prompt (SYSTEM, ROLE, CONTEXT, OBJECTIVE, CONSTRAINTS, OUTPUT_FORMAT) |
  | **Cost Estimator** | Token badge in the output header — click to see estimated input cost across major models (GPT-4o, Claude, Gemini…) |
  | **Context Memory** | IndexedDB-persisted reusable blocks with categories, tags, favorites and canvas injection |
  | **Version History** | Save named snapshots of the canvas, restore any version, compare two versions with a line-level diff viewer |

  ---

  ### Technical changes

  **Backend (FastAPI)**
  - 4 new routers: `/api/debug`, `/api/compress`, `/api/critic`, `/api/system-prompt`
  - 4 Pydantic models + 4 service files calling Claude via `_call_llm_direct`
  - All endpoints accept a `locale` field and instruct the AI to respond in the user's UI language

  **Frontend (React + TypeScript)**
  - Feature-first structure: `src/features/{debugger,compressor,critic,system-prompt,cost-estimator,context-memory,versioning}/`
  - Zustand stores for each feature (transient state: open/loading/result/error)
  - IndexedDB via `idb` for persistent client-side data (memory blocks, versions)
  - LCS-based diff algorithm (`src/lib/diff.ts`) for the version diff viewer
  - `locale` passed from `useLocale()` to all 4 API calls

  **i18n**
  - Full `ide` namespace added to `en.json` and `fr.json`
  - Typed in `translations.ts`
  - Critic dimension names translated client-side via `tc.dimensions[d.name]`

  **CSS**
  - `.ide-close-btn` and `.ide-action-btn` — two new shared utility classes used across all panels
  - Styles for all new panels (debugger, compressor, critic, system prompt, memory, versioning, diff viewer, cost popover)
  - Fixed Make.com panel z-index (was rendering below the project header)

  ---

  ### Bug fixes

  - `api.ts` — explicit `snake_case` → `camelCase` mapping for all 4 new endpoints (fixes compressor not applying results)
  - All new components now use `useLocale()` instead of hardcoded English strings
  - Close/action buttons replaced with proper `.ide-close-btn` / `.ide-action-btn` classes


----
<img width="912" height="494" alt="image" src="https://github.com/user-attachments/assets/cecb43c0-180f-4ebf-aa08-5b5d45b2d6dd" />
<img width="3024" height="1702" alt="image" src="https://github.com/user-attachments/assets/540aa627-5838-4a00-b040-51686851bc7e" />
<img width="3024" height="1702" alt="image" src="https://github.com/user-attachments/assets/d3dcec76-354e-4cde-98b4-abcfed4a2cb8" />
<img width="3024" height="1702" alt="image" src="https://github.com/user-attachments/assets/338c3096-1b65-4ab9-9c0b-f98575930f3d" />
<img width="3024" height="1702" alt="image" src="https://github.com/user-attachments/assets/1906c140-b5ee-4db8-a4f5-8021a78eeb95" />
<img width="914" height="794" alt="image" src="https://github.com/user-attachments/assets/0e06dfe5-ab3e-4b0d-9b66-0ee0e0eb9b1c" />
<img width="914" height="1706" alt="image" src="https://github.com/user-attachments/assets/97523290-5ea7-42d1-98b7-91c5e7fa6971" />
